### PR TITLE
Connect Upcoming Events Page to Backend

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -1,0 +1,26 @@
+import { EventProps } from '../containers/upcoming-events/ducks/types';
+import AppAxiosInstance from '../auth/axios';
+
+export interface ApiExtraArgs {
+  readonly protectedApiClient: ProtectedApiClient
+}
+
+export interface ProtectedApiClient {
+  readonly getUpcomingEvents: () => Promise<EventProps[]>;
+}
+
+enum ProtectedApiClientRoutes {
+  UPCOMING_EVENTS = '/api/v1/protected/events/qualified/',
+}
+
+const getUpcomingEvents = (): Promise<EventProps[]> => {
+  return AppAxiosInstance.get(ProtectedApiClientRoutes.UPCOMING_EVENTS).then(
+    (response) => response.data.events,
+  );
+};
+
+const Client: ProtectedApiClient = Object.freeze({
+  getUpcomingEvents,
+});
+
+export default Client;

--- a/src/auth/authClient.tsx
+++ b/src/auth/authClient.tsx
@@ -7,10 +7,10 @@ import {
 import axios, { AxiosInstance } from 'axios';
 
 export interface AuthClient {
-  login: (user: LoginRequest) => Promise<TokenPayload>;
-  signup: (user: SignupRequest) => Promise<TokenPayload>;
-  logout: (refreshToken: string) => Promise<void>;
-  refresh: (refreshToken: string) => Promise<RefreshTokenResponse>;
+  readonly login: (user: LoginRequest) => Promise<TokenPayload>;
+  readonly signup: (user: SignupRequest) => Promise<TokenPayload>;
+  readonly logout: (refreshToken: string) => Promise<void>;
+  readonly refresh: (refreshToken: string) => Promise<RefreshTokenResponse>;
 }
 
 export enum API_ROUTE {

--- a/src/auth/axios.ts
+++ b/src/auth/axios.ts
@@ -1,6 +1,4 @@
 import axios, { AxiosInstance } from 'axios';
-import store, { C4CState } from '../store';
-import { AsyncRequestKinds } from '../utils/asyncRequest';
 
 const AppAxiosInstance: AxiosInstance = axios.create({
   baseURL: process.env.REACT_APP_API_DOMAIN,
@@ -10,15 +8,15 @@ const AppAxiosInstance: AxiosInstance = axios.create({
   },
 });
 
-const listener = () => {
-  const state: C4CState = store.getState();
-  if (state.authenticationState.tokens.kind === AsyncRequestKinds.Completed) {
-    AppAxiosInstance.defaults.headers['X-Access-Token'] =
-      state.authenticationState.tokens.result.accessToken;
-  }
-};
-
-store.subscribe(listener);
+// const listener = () => {
+//   const state: C4CState = store.getState();
+//   if (state.authenticationState.tokens.kind === AsyncRequestKinds.Completed) {
+//     AppAxiosInstance.defaults.headers['X-Access-Token'] =
+//       state.authenticationState.tokens.result.accessToken;
+//   }
+// };
+//
+// // store.subscribe(listener);
 
 // const responseErrorInterceptor: (error: AxiosError) => void = (error) => {
 //   // const originalRequest = error.config;

--- a/src/auth/ducks/thunks.ts
+++ b/src/auth/ducks/thunks.ts
@@ -5,6 +5,7 @@ import {
   UserAuthenticationThunkAction,
 } from './types';
 import { authenticateUser, logoutUser } from './actions';
+import AppAxiosInstance from '../axios';
 
 export const login = (
   loginRequest: LoginRequest,
@@ -14,6 +15,8 @@ export const login = (
       .login(loginRequest)
       .then((response: TokenPayload) => {
         // TODO: move this side effect somewhere else
+        AppAxiosInstance.defaults.headers['X-Access-Token'] =
+          response.accessToken;
         tokenService.setRefreshToken(response.refreshToken);
         dispatch(authenticateUser.loaded(response));
       })
@@ -31,6 +34,8 @@ export const signup = (
       .signup(signupRequest)
       .then((response) => {
         // TODO: move this side effect somewhere else
+        AppAxiosInstance.defaults.headers['X-Access-Token'] =
+          response.accessToken;
         tokenService.setRefreshToken(response.refreshToken);
         dispatch(authenticateUser.loaded(response));
       })
@@ -47,6 +52,7 @@ export const logout = (): UserAuthenticationThunkAction<void> => {
       dispatch(logoutUser.loaded());
       return Promise.resolve();
     }
+    delete AppAxiosInstance.defaults.headers['X-Access-Token'];
     return authClient
       .logout(refreshToken)
       .then(() => {

--- a/src/components/event-listing/EventListing.tsx
+++ b/src/components/event-listing/EventListing.tsx
@@ -42,7 +42,7 @@ const Info = styled.div`
 `;
 
 const EventListing: React.FC<EventProps> = ({
-  src,
+  thumbnail,
   title,
   date,
   description,
@@ -53,7 +53,7 @@ const EventListing: React.FC<EventProps> = ({
   return (
     <StyledCard>
       <CardContent>
-        <Thumbnail src={src || defaultImg}></Thumbnail>
+        <Thumbnail src={thumbnail || defaultImg} />
         <Info>
           <Title level={3}>{title}</Title>
           <Text strong>{dateFormat(date, 'longDate')}</Text>

--- a/src/components/events-list/EventsList.tsx
+++ b/src/components/events-list/EventsList.tsx
@@ -2,32 +2,11 @@ import React from 'react';
 import EventListing from '../event-listing/EventListing';
 import { EventProps } from '../../containers/upcoming-events/ducks/types';
 
-const EventsList: React.FC = () => {
-  // mock data to use for now
-  const event1: EventProps = {
-    title: 'Dolphins and Massage!',
-    date: new Date('2020/12/12'),
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. ',
-    src:
-      'https://mymodernmet.com/wp/wp-content/uploads/2020/12/how-to-draw-a-dolphin-large-thumbnail-1.jpg',
-  };
-  const event2: EventProps = {
-    title: 'VIRTUAL Barn Babies',
-    date: new Date('2020/11/28'),
-    description:
-      'Find some time for self-care and join yoga teacher Sarah Oleson for a peaceful and rejuvenating virtual restorative yoga session! Find a comfortable spot and grab a mat and a blanket and/or bolster. Open to all abilities. ',
-    src:
-      'https://img.apmcdn.org/de59f2dc867d1c2a8bb59503661fbee0c95f3e53/uncropped/680ab2-20170324-babyfarmanimals-17.jpg',
-  };
-  const event3: EventProps = {
-    title: 'Default Event',
-    date: new Date('2020/11/18'),
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborumLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-  };
-  const events: EventProps[] = [event1, event2, event3];
+export interface EventsListProps {
+  readonly events: EventProps[]
+}
 
+const EventsList: React.FC<EventsListProps> = ({events}) => {
   return (
     <div className="cards">
       {events.map((event, i) => (

--- a/src/containers/upcoming-events/UpcomingEvents.tsx
+++ b/src/containers/upcoming-events/UpcomingEvents.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { Typography, Radio } from 'antd';
+import { Radio, Typography } from 'antd';
 import EventsList from '../../components/events-list/EventsList';
 import styled from 'styled-components';
 import { ChungusContentContainer } from '../../components';
-import { ORANGE } from '../../colors';
+import { C4CState } from '../../store';
+import { EventsReducerState } from './ducks/types';
+import { connect, useDispatch } from 'react-redux';
+import { AsyncRequestKinds } from '../../utils/asyncRequest';
+import { getUpcomingEvents } from './ducks/thunks';
 
 const { Title } = Typography;
 
@@ -23,7 +27,16 @@ const StyledTitle = styled(Title)`
   margin-left: 0px;
 `;
 
-const Events: React.FC = () => {
+interface UpcomingEventsProps {
+  readonly events: EventsReducerState['upcomingEvents'];
+}
+
+const UpcomingEvents: React.FC<UpcomingEventsProps> = ({ events }) => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getUpcomingEvents());
+  }, []);
+
   return (
     <>
       <Helmet>
@@ -38,10 +51,18 @@ const Events: React.FC = () => {
             <Radio.Button value="calendar">Calendar</Radio.Button>
           </StyledRadio>
         </Content>
-        <EventsList></EventsList>
+        {events.kind === AsyncRequestKinds.Completed && (
+          <EventsList events={events.result} />
+        )}
       </ChungusContentContainer>
     </>
   );
 };
 
-export default Events;
+const mapStateToProps = (state: C4CState): UpcomingEventsProps => {
+  return {
+    events: state.eventsState.upcomingEvents,
+  };
+};
+
+export default connect(mapStateToProps)(UpcomingEvents);

--- a/src/containers/upcoming-events/ducks/actions.ts
+++ b/src/containers/upcoming-events/ducks/actions.ts
@@ -1,0 +1,9 @@
+import { genericAsyncActions } from '../../../utils/asyncRequest';
+import { EventProps } from './types';
+
+export const upcomingEvents = genericAsyncActions<EventProps[], any>();
+
+export type EventsActions =
+  | ReturnType<typeof upcomingEvents.loading>
+  | ReturnType<typeof upcomingEvents.loaded>
+  | ReturnType<typeof upcomingEvents.failed>

--- a/src/containers/upcoming-events/ducks/reducers.ts
+++ b/src/containers/upcoming-events/ducks/reducers.ts
@@ -1,0 +1,39 @@
+import { EventProps, EventsReducerState } from './types';
+import {
+  ASYNC_REQUEST_FAILED_ACTION,
+  ASYNC_REQUEST_LOADED_ACTION,
+  ASYNC_REQUEST_LOADING_ACTION,
+  AsyncRequestNotStarted,
+  generateAsyncRequestReducer,
+} from '../../../utils/asyncRequest';
+import { upcomingEvents } from './actions';
+import { C4CAction } from '../../../store';
+
+export const initialEventsState: EventsReducerState = {
+  upcomingEvents: AsyncRequestNotStarted<EventProps[], any>(),
+};
+
+const upcomingEventsReducer = generateAsyncRequestReducer<
+  EventsReducerState,
+  EventProps[],
+  void
+>(upcomingEvents.key);
+
+const reducers = (
+  state: EventsReducerState = initialEventsState,
+  action: C4CAction,
+): EventsReducerState => {
+  switch (action.type) {
+    case ASYNC_REQUEST_LOADING_ACTION:
+    case ASYNC_REQUEST_LOADED_ACTION:
+    case ASYNC_REQUEST_FAILED_ACTION:
+      return {
+        ...state,
+        upcomingEvents: upcomingEventsReducer(state.upcomingEvents, action),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducers;

--- a/src/containers/upcoming-events/ducks/thunks.ts
+++ b/src/containers/upcoming-events/ducks/thunks.ts
@@ -1,0 +1,16 @@
+import { EventProps, EventsThunkAction } from './types';
+import { upcomingEvents } from './actions';
+
+export const getUpcomingEvents = (): EventsThunkAction<void> => {
+  return (dispatch, getState, { protectedApiClient }) => {
+    dispatch(upcomingEvents.loading());
+    return protectedApiClient
+      .getUpcomingEvents()
+      .then((response: EventProps[]) => {
+        dispatch(upcomingEvents.loaded(response));
+      })
+      .catch((error: any) => {
+        dispatch(upcomingEvents.failed(error));
+      });
+  };
+};

--- a/src/containers/upcoming-events/ducks/types.ts
+++ b/src/containers/upcoming-events/ducks/types.ts
@@ -20,5 +20,5 @@ export interface EventProps {
   date: Date;
   description: string;
   otherNotes?: string;
-  src?: string;
+  thumbnail?: string;
 }

--- a/src/containers/upcoming-events/ducks/types.ts
+++ b/src/containers/upcoming-events/ducks/types.ts
@@ -1,3 +1,20 @@
+import { AsyncRequest } from '../../../utils/asyncRequest';
+import { C4CState } from '../../../store';
+import { ThunkAction } from 'redux-thunk';
+import { EventsActions } from './actions';
+import { ApiExtraArgs } from '../../../api/protectedApiClient';
+
+export interface EventsReducerState {
+  readonly upcomingEvents: AsyncRequest<EventProps[], any>;
+}
+
+export type EventsThunkAction<R> = ThunkAction<
+  R,
+  C4CState,
+  ApiExtraArgs,
+  EventsActions
+>;
+
 export interface EventProps {
   title: string;
   date: Date;

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,9 +15,16 @@ import userReducer, { initialUserState } from './auth/ducks/reducers';
 import { ThunkDispatch } from '@reduxjs/toolkit';
 import thunk from 'redux-thunk';
 import tokenService from './auth/token';
+import protectedApiClient, { ApiExtraArgs } from './api/protectedApiClient';
+import { EventsReducerState } from './containers/upcoming-events/ducks/types';
+import { EventsActions } from './containers/upcoming-events/ducks/actions';
+import eventsReducer, {
+  initialEventsState,
+} from './containers/upcoming-events/ducks/reducers';
 
 export interface C4CState {
   authenticationState: UserAuthenticationReducerState;
+  eventsState: EventsReducerState;
 }
 
 export interface Action<T, P> {
@@ -25,21 +32,24 @@ export interface Action<T, P> {
   readonly payload: P;
 }
 
-export type C4CAction = UserAuthenticationActions;
+export type C4CAction = UserAuthenticationActions & EventsActions;
 
-export type ThunkExtraArgs = UserAuthenticationExtraArgs;
+export type ThunkExtraArgs = UserAuthenticationExtraArgs & ApiExtraArgs;
 
 const reducers = combineReducers<C4CState, C4CAction>({
   authenticationState: userReducer,
+  eventsState: eventsReducer,
 });
 
 export const initialStoreState: C4CState = {
   authenticationState: initialUserState,
+  eventsState: initialEventsState,
 };
 
 const thunkExtraArgs: ThunkExtraArgs = {
   authClient,
   tokenService,
+  protectedApiClient,
 };
 
 const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__


### PR DESCRIPTION
## Why

We want to start incrementally connecting the new frontend to the backend! 

## This PR

Connects the events list shown on the upcoming events page to the existing backend route for getting events. 

(note: must be signed in for functionality to work) 
(note: the EventProps interface must be updated to reflect data returned by the API)
(note: this will likely ultimately point to a new backend route, which is not protected, but this is a step in the right direction)

## Screenshots

<img width="1792" alt="Screen Shot 2021-01-05 at 9 45 07 PM" src="https://user-images.githubusercontent.com/15748593/103733864-8550ee00-4f9f-11eb-9d90-8104a5d8485f.png">
@bensenescu 😉 
