### PR TITLE
added correct return types, added interface for SignupForm props

### DIFF
--- a/src/containers/signupForm/index.tsx
+++ b/src/containers/signupForm/index.tsx
@@ -17,13 +17,12 @@ import { useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { Routes } from '../../App';
 import { signup } from '../../auth/ducks/thunks';
-import { TokenPayload } from '../../auth/ducks/types';
+import { UserAuthenticationReducerState } from '../../auth/ducks/types';
 import { ContentContainer } from '../../components';
 import FormContainer from '../../components/FormContainer';
 import FormInitialText from '../../components/FormInitialText';
 import { C4CState } from '../../store';
 import {
-  AsyncRequest,
   asyncRequestIsComplete,
   asyncRequestIsFailed,
   asyncRequestIsLoading,
@@ -43,9 +42,11 @@ const PaddedAlert = styled(Alert)`
   margin-bottom: 2em;
 `;
 
-const SignupForm: React.FC<{ tokens: AsyncRequest<TokenPayload, any> }> = ({
-  tokens,
-}) => {
+interface SignupFormProps {
+  readonly tokens: UserAuthenticationReducerState['tokens'];
+}
+
+const SignupForm: React.FC<SignupFormProps> = ({ tokens }) => {
   const dispatch = useDispatch();
   const history = useHistory();
   const location = useLocation();
@@ -503,7 +504,7 @@ const SignupForm: React.FC<{ tokens: AsyncRequest<TokenPayload, any> }> = ({
   );
 };
 
-const mapStateToProps = (state: C4CState) => {
+const mapStateToProps = (state: C4CState): SignupFormProps => {
   return {
     tokens: state.authenticationState.tokens,
   };

--- a/src/utils/asyncRequest.ts
+++ b/src/utils/asyncRequest.ts
@@ -99,7 +99,7 @@ export function asyncRequestIsComplete<R, E = void>(
 
 export function asyncRequestIsLoading<R, E = void>(
   request: AsyncRequest<R, E>,
-): boolean {
+): request is Loading {
   switch (request.kind) {
     case AsyncRequestKinds.Loading:
       return true;
@@ -112,7 +112,7 @@ export function asyncRequestIsLoading<R, E = void>(
 
 export function asyncRequestIsFailed<R, E = void>(
   request: AsyncRequest<R, E>,
-): boolean {
+): request is Failed<E> {
   switch (request.kind) {
     case AsyncRequestKinds.Failed:
       return true;
@@ -125,7 +125,7 @@ export function asyncRequestIsFailed<R, E = void>(
 
 export function asyncRequestIsNotStarted<R, E = void>(
   request: AsyncRequest<R, E>,
-): boolean {
+): request is NotStarted {
   switch (request.kind) {
     case AsyncRequestKinds.NotStarted:
       return true;


### PR DESCRIPTION
## Issue

None. Related to https://github.com/Code-4-Community/frontend-scaffold/issues/40

## Changes

- altered return types of async request utility functions
- added interface for SignupForm, `SignupFormProps`, as opposed to inline definitions. 

## Screenshots

Not applicable. 

## Verification Steps

Ran `npm run type-check`