### PR TITLE
Added Types to UseParam<>() to pass typescript checks

### DIFF
--- a/src/containers/forgotPasswordReset/index.tsx
+++ b/src/containers/forgotPasswordReset/index.tsx
@@ -13,7 +13,7 @@ interface NewPasswords {
 }
 
 const ForgotPasswordReset: React.FC = () => {
-  const { key } = useParams();
+  const { key } = useParams<{key: string}>();
   const [error, setError] = useState<boolean>(false);
   const history = useHistory();
 

--- a/src/containers/forgotPasswordReset/index.tsx
+++ b/src/containers/forgotPasswordReset/index.tsx
@@ -13,7 +13,7 @@ interface NewPasswords {
 }
 
 const ForgotPasswordReset: React.FC = () => {
-  const { key } = useParams<{key: string}>();
+  const { key } = useParams<{ key: string }>();
   const [error, setError] = useState<boolean>(false);
   const history = useHistory();
 

--- a/src/containers/verifyEmail/index.tsx
+++ b/src/containers/verifyEmail/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../utils/asyncRequest';
 
 const VerifyEmail: React.FC = () => {
-  const { key } = useParams<{key: string}>();
+  const { key } = useParams<{ key: string }>();
   const [status, setStatus] = useState<AsyncRequest>(AsyncRequestNotStarted());
 
   useEffect(() => {

--- a/src/containers/verifyEmail/index.tsx
+++ b/src/containers/verifyEmail/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../utils/asyncRequest';
 
 const VerifyEmail: React.FC = () => {
-  const { key } = useParams();
+  const { key } = useParams<{key: string}>();
   const [status, setStatus] = useState<AsyncRequest>(AsyncRequestNotStarted());
 
   useEffect(() => {


### PR DESCRIPTION
## Issue

When running `tsc` master was failing (but somehow was passing npm run check? I have no clue why)

## Changes

Added {key: string} as the type for both useParam calls

## Verification Steps
![image](https://user-images.githubusercontent.com/23691775/112361056-5f3b1000-8ca9-11eb-95b6-966242819f08.png)
