### PR TITLE
add min height to cards

### DIFF
--- a/src/components/AnnouncementCard.tsx
+++ b/src/components/AnnouncementCard.tsx
@@ -18,6 +18,7 @@ const AnnouncementCardNoCover = styled(Card)`
   min-width: 200px;
   max-width: 400px;
   margin: 16px 16px;
+  min-height: 400px;
 
   @media screen and (min-width: 800px) {
     min-width: 400px;


### PR DESCRIPTION
## Changes

Briefly list the changes made to the code:

- Added min height to cards so that they are all more or less the same base height. This is more consistent with the Figma designs

## Screenshots

![image](https://user-images.githubusercontent.com/23691775/112365129-ac20e580-8cad-11eb-9f4a-089b44253571.png)

![image](https://user-images.githubusercontent.com/23691775/112365310-e2f6fb80-8cad-11eb-87c4-34470a038f94.png)


