### PR TITLE
added admin buttons

### DIFF
--- a/src/containers/singleEvent/index.tsx
+++ b/src/containers/singleEvent/index.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import { PrivilegeLevel } from '../../auth/ducks/types';
 import EventDetails from '../../components/event-details/EventDetails';
+import { LinkButton } from '../../components/LinkButton';
 import { C4CState } from '../../store';
 import {
   AsyncRequest,
@@ -33,7 +34,7 @@ const AdminActionButtonList = styled.div`
   display: flex;
 `;
 
-const GreenButton = styled(Button)`
+const StyledButton = styled(LinkButton)`
   display: flex;
   flex-direction: column;
   text-align: center;
@@ -42,10 +43,14 @@ const GreenButton = styled(Button)`
   margin-bottom: 32px;
   margin-right: 16px;
   padding: 8px 16px;
+`;
+
+const GreenButton = styled(StyledButton)`
+  background-color: #2d870d;
   color: #ffffff;
 `;
 
-const RedButton = styled(GreenButton)`
+const RedButton = styled(StyledButton)`
   background-color: #ff4d4f;
   border-color: #ff4d4f;
 
@@ -53,9 +58,15 @@ const RedButton = styled(GreenButton)`
     border-color: #ff4d4f;
     color: #ff4d4f;
   }
+
+  &:focus {
+    background-color: white;
+    color: #ff4d4f;
+    border-color: #ff4d4f;
+  }
 `;
 
-const GrayButton = styled(GreenButton)`
+const GrayButton = styled(StyledButton)`
   background-color: white;
   color: #595959;
 
@@ -63,6 +74,12 @@ const GrayButton = styled(GreenButton)`
     border-color: #595959;
     color: white;
     background-color: #595959;
+  }
+
+  &:focus {
+    background-color: white;
+    color: #595959;
+    border-color: #595959;
   }
 `;
 
@@ -95,7 +112,21 @@ const SingleEvent: React.FC<SingleEventProps> = ({ events }) => {
       const event = eventsList.result.filter((e) => e.id === id);
 
       if (event.length > 0) {
-        return <EventDetails {...event[0]} />;
+        return (
+          <>
+            {privilegeLevel === PrivilegeLevel.ADMIN ? (
+              <AdminActionButtonList>
+                <GreenButton to={'/events/' + id}>Edit</GreenButton>
+                <GreenButton to={'/events/' + id}>
+                  Make Announcement
+                </GreenButton>
+                <RedButton to={'/events/' + id}>Delete Event</RedButton>
+                <GrayButton to={'/events/' + id}>View RSVP</GrayButton>
+              </AdminActionButtonList>
+            ) : null}
+            <EventDetails {...event[0]} />
+          </>
+        );
       } else {
         return <p>That event does not exist!</p>;
       }
@@ -120,14 +151,6 @@ const SingleEvent: React.FC<SingleEventProps> = ({ events }) => {
         />
       </Helmet>
       <ContentContainer>
-        {privilegeLevel === PrivilegeLevel.ADMIN ? (
-          <AdminActionButtonList>
-            <GreenButton>Edit</GreenButton>
-            <GreenButton>Make Announcement</GreenButton>
-            <RedButton>Delete Event</RedButton>
-            <GrayButton>View RSVP</GrayButton>
-          </AdminActionButtonList>
-        ) : null}
         {conditionalRenderEventDetails(events)}
       </ContentContainer>
     </>

--- a/src/containers/singleEvent/index.tsx
+++ b/src/containers/singleEvent/index.tsx
@@ -18,6 +18,8 @@ import {
 import { getUpcomingEvents } from '../upcoming-events/ducks/thunks';
 import { EventProps, EventsReducerState } from '../upcoming-events/ducks/types';
 
+const BASE_EVENTS_ROUTE = '/events/';
+
 const ContentContainer = styled.div`
   padding: 24px;
   margin: auto;
@@ -40,8 +42,7 @@ const StyledButton = styled(LinkButton)`
   text-align: center;
   justify-content: center;
   background-color: #2d870d;
-  margin-bottom: 32px;
-  margin-right: 16px;
+  margin: 0 16px 32px 0;
   padding: 8px 16px;
 `;
 
@@ -114,16 +115,16 @@ const SingleEvent: React.FC<SingleEventProps> = ({ events }) => {
       if (event.length > 0) {
         return (
           <>
-            {privilegeLevel === PrivilegeLevel.ADMIN ? (
+            {privilegeLevel === PrivilegeLevel.ADMIN && (
               <AdminActionButtonList>
-                <GreenButton to={'/events/' + id}>Edit</GreenButton>
-                <GreenButton to={'/events/' + id}>
+                <GreenButton to={BASE_EVENTS_ROUTE + id}>Edit</GreenButton>
+                <GreenButton to={BASE_EVENTS_ROUTE + id}>
                   Make Announcement
                 </GreenButton>
-                <RedButton to={'/events/' + id}>Delete Event</RedButton>
-                <GrayButton to={'/events/' + id}>View RSVP</GrayButton>
+                <RedButton to={BASE_EVENTS_ROUTE + id}>Delete Event</RedButton>
+                <GrayButton to={BASE_EVENTS_ROUTE + id}>View RSVP</GrayButton>
               </AdminActionButtonList>
-            ) : null}
+            )}
             <EventDetails {...event[0]} />
           </>
         );

--- a/src/containers/singleEvent/index.tsx
+++ b/src/containers/singleEvent/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Spin } from 'antd';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
@@ -54,6 +54,7 @@ const RedButton = styled(GreenButton)`
     color: #ff4d4f;
   }
 `;
+
 const GrayButton = styled(GreenButton)`
   background-color: white;
   color: #595959;

--- a/src/containers/singleEvent/index.tsx
+++ b/src/containers/singleEvent/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Spin } from 'antd';
+import { Spin } from 'antd';
 import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect, useDispatch, useSelector } from 'react-redux';

--- a/src/containers/singleEvent/index.tsx
+++ b/src/containers/singleEvent/index.tsx
@@ -1,9 +1,11 @@
-import { Spin } from 'antd';
-import React, { useEffect } from 'react';
+import { Button, Spin } from 'antd';
+import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { PrivilegeLevel } from '../../auth/ducks/types';
 import EventDetails from '../../components/event-details/EventDetails';
 import { C4CState } from '../../store';
 import {
@@ -27,6 +29,42 @@ const CenteredContainer = styled.div`
   justify-content: center;
 `;
 
+const AdminActionButtonList = styled.div`
+  display: flex;
+`;
+
+const GreenButton = styled(Button)`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
+  background-color: #2d870d;
+  margin-bottom: 32px;
+  margin-right: 16px;
+  padding: 8px 16px;
+  color: #ffffff;
+`;
+
+const RedButton = styled(GreenButton)`
+  background-color: #ff4d4f;
+  border-color: #ff4d4f;
+
+  &:hover {
+    border-color: #ff4d4f;
+    color: #ff4d4f;
+  }
+`;
+const GrayButton = styled(GreenButton)`
+  background-color: white;
+  color: #595959;
+
+  &:hover {
+    border-color: #595959;
+    color: white;
+    background-color: #595959;
+  }
+`;
+
 interface SingleEventProps {
   readonly events: EventsReducerState['upcomingEvents'];
 }
@@ -42,6 +80,10 @@ const SingleEvent: React.FC<SingleEventProps> = ({ events }) => {
       dispatch(getUpcomingEvents());
     }
   }, [dispatch, events]);
+
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) => {
+    return getPrivilegeLevel(state.authenticationState.tokens);
+  });
 
   const id = Number(useParams<SingleEventParams>().id);
 
@@ -77,6 +119,14 @@ const SingleEvent: React.FC<SingleEventProps> = ({ events }) => {
         />
       </Helmet>
       <ContentContainer>
+        {privilegeLevel === PrivilegeLevel.ADMIN ? (
+          <AdminActionButtonList>
+            <GreenButton>Edit</GreenButton>
+            <GreenButton>Make Announcement</GreenButton>
+            <RedButton>Delete Event</RedButton>
+            <GrayButton>View RSVP</GrayButton>
+          </AdminActionButtonList>
+        ) : null}
         {conditionalRenderEventDetails(events)}
       </ContentContainer>
     </>


### PR DESCRIPTION
## Issue

Closes #90 

## Changes

Adds new interface with 'Edit', 'Make Announcement', 'Delete Event', and 'View RSVP' buttons to single event view for admins.

## Screenshots

![llbsc1](https://user-images.githubusercontent.com/57075562/113231988-4fec3180-926a-11eb-9fae-24d444621fc4.jpg)

## Verification Steps

- Verify that the buttons only appear when logged in as an admin
