### PR TITLE
Fixed broken link on Events List page

### DIFF
--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -139,7 +139,7 @@ const Home: React.FC<HomeContainerProps> = ({ events, announcements }) => {
                   title={event.title}
                   date={event.details.start}
                   description={event.details.description}
-                  to={`${Routes.EVENT}/${event.id}`}
+                  to={`/events/${event.id}`}
                 />
               </Col>
             ))}

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -3,7 +3,6 @@ import { default as React, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect, useDispatch } from 'react-redux';
 import styled from 'styled-components';
-import { Routes } from '../../App';
 import AnnouncementsList from '../../components/announcementsList';
 import EventCard from '../../components/EventCard';
 import { LinkButton } from '../../components/LinkButton';


### PR DESCRIPTION
## Issue


## Changes

Previous the link was broken, as using the Routes.EVENTS constant used the :id param for routing that doesnt work for a literal path. Now it simply uses `/events/${id}`