### PR TITLE
Create Event RSVP page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import PersonalRequests from './containers/personalRequests';
 import { useSelector } from 'react-redux';
 import { C4CState } from './store';
 import { getPrivilegeLevel } from './auth/ducks/selectors';
+import EventRSVP from './containers/eventRSVP';
 
 const { Content } = Layout;
 
@@ -42,6 +43,7 @@ export enum Routes {
   PERSONAL_REQUESTS = '/personal-requests',
   EDIT_FAMILY_INFO = '/edit-family-information',
   DEACTIVATE_ACCOUNT = '/deactivate-account',
+  EVENT_REGISTRATIONS = '/events/:id/rsvp',
 }
 
 const App: React.FC = () => {
@@ -65,6 +67,57 @@ const App: React.FC = () => {
             {(() => {
               switch (privilegeLevel) {
                 case PrivilegeLevel.ADMIN:
+                  return (
+                    <Switch>
+                      <Route path={Routes.HOME} exact component={Home} />
+                      <Route
+                        path={Routes.UPCOMING_EVENTS}
+                        exact
+                        component={UpcomingEvents}
+                      />
+                      <Route
+                        path={Routes.EVENT}
+                        exact
+                        component={SingleEvent}
+                      />
+                      <Route
+                        path={Routes.ANNOUNCEMENTS}
+                        exact
+                        component={Announcements}
+                      />
+                      <Route
+                        path={Routes.SETTINGS}
+                        exact
+                        component={Settings}
+                      />
+                      <Route
+                        path={Routes.DEACTIVATE_ACCOUNT}
+                        exact
+                        component={DeactivateAccount}
+                      />
+                      <Route
+                        path={Routes.SIGNUP_FORM}
+                        exact
+                        component={SignupFormContainer}
+                      />
+                      <Route
+                        path={Routes.VERIFY_EMAIL}
+                        exact
+                        component={VerifyEmail}
+                      />
+                      <Route
+                        path={Routes.PERSONAL_REQUESTS}
+                        exact
+                        component={PersonalRequests}
+                      />
+                      <Route
+                        path={Routes.EVENT_REGISTRATIONS}
+                        exact
+                        component={EventRSVP}
+                      />
+                      <Route path="*" exact component={NotFound} />
+                    </Switch>
+                  );
                 case PrivilegeLevel.STANDARD:
                 case PrivilegeLevel.PF:
                   return (

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -1,4 +1,5 @@
 import AppAxiosInstance from '../auth/axios';
+import { Registration } from '../containers/eventRSVP/ducks/types';
 import { PersonalRequest } from '../containers/personalRequests/ducks/types';
 
 export interface ProtectedApiExtraArgs {
@@ -13,6 +14,7 @@ export interface ProtectedApiClient {
   readonly getRequestStatuses: () => Promise<PersonalRequest[]>;
   readonly makePFRequest: () => Promise<void>;
   readonly deactivateAccount: () => Promise<void>;
+  readonly getEventRegistrations: (eventId: number) => Promise<Registration[]>;
 }
 
 export enum ProtectedApiClientRoutes {
@@ -20,6 +22,7 @@ export enum ProtectedApiClientRoutes {
   REQUEST_STATUSES = '/api/v1/protected/requests/status',
   MAKE_PF_REQUEST = 'api/v1/protected/requests',
   USER = '/api/v1/protected/user',
+  EVENTS = 'api/v1/protected/events',
 }
 
 const changePassword = (request: {
@@ -52,11 +55,20 @@ const makePFRequest = (): Promise<void> => {
     .catch((err) => err);
 };
 
+const getEventRegistrations: (eventId: number) => Promise<Registration[]> = (
+  eventId: number,
+) => {
+  return AppAxiosInstance.get(
+    `${ProtectedApiClientRoutes.EVENTS}/${eventId}/registrations`,
+  ).then((res) => res.data.registrations);
+};
+
 const Client: ProtectedApiClient = Object.freeze({
   changePassword,
   getRequestStatuses,
   makePFRequest,
   deactivateAccount,
+  getEventRegistrations,
 });
 
 export default Client;

--- a/src/containers/eventRSVP/ducks/actions.ts
+++ b/src/containers/eventRSVP/ducks/actions.ts
@@ -3,7 +3,7 @@ import { Registration } from './types';
 
 export const eventRegistrations = genericAsyncActions<Registration[], any>();
 
-export type EventsRSVPActions =
+export type EventRegistrationsActions =
   | ReturnType<typeof eventRegistrations.loading>
   | ReturnType<typeof eventRegistrations.loaded>
   | ReturnType<typeof eventRegistrations.failed>;

--- a/src/containers/eventRSVP/ducks/actions.ts
+++ b/src/containers/eventRSVP/ducks/actions.ts
@@ -1,5 +1,5 @@
 import { genericAsyncActions } from '../../../utils/asyncRequest';
-import {  Registration } from './types';
+import { Registration } from './types';
 
 export const eventRegistrations = genericAsyncActions<Registration[], any>();
 

--- a/src/containers/eventRSVP/ducks/actions.ts
+++ b/src/containers/eventRSVP/ducks/actions.ts
@@ -1,0 +1,9 @@
+import { genericAsyncActions } from '../../../utils/asyncRequest';
+import {  Registration } from './types';
+
+export const eventRegistrations = genericAsyncActions<Registration[], any>();
+
+export type EventsRSVPActions =
+  | ReturnType<typeof eventRegistrations.loading>
+  | ReturnType<typeof eventRegistrations.loaded>
+  | ReturnType<typeof eventRegistrations.failed>;

--- a/src/containers/eventRSVP/ducks/reducers.ts
+++ b/src/containers/eventRSVP/ducks/reducers.ts
@@ -4,15 +4,14 @@ import {
   ASYNC_REQUEST_FAILED_ACTION,
   ASYNC_REQUEST_LOADED_ACTION,
   ASYNC_REQUEST_LOADING_ACTION,
-
-  generateAsyncRequestReducer
+  generateAsyncRequestReducer,
 } from '../../../utils/asyncRequest';
 import { eventRegistrations } from './actions';
 import { EventRegistrationsReducerState, Registration } from './types';
 
 export const initialEventRegistrationsState: EventRegistrationsReducerState = {
-  eventRegistrations:  AsyncRequestNotStarted<Registration[], any>(),
-}
+  eventRegistrations: AsyncRequestNotStarted<Registration[], any>(),
+};
 
 const eventRegistrationsReducer = generateAsyncRequestReducer<
   EventRegistrationsReducerState,
@@ -30,7 +29,10 @@ const reducers = (
     case ASYNC_REQUEST_FAILED_ACTION:
       return {
         ...state,
-        eventRegistrations: eventRegistrationsReducer(state.eventRegistrations, action),
+        eventRegistrations: eventRegistrationsReducer(
+          state.eventRegistrations,
+          action,
+        ),
       };
     default:
       return state;

--- a/src/containers/eventRSVP/ducks/reducers.ts
+++ b/src/containers/eventRSVP/ducks/reducers.ts
@@ -1,0 +1,40 @@
+import { C4CAction } from '../../../store';
+import {
+  AsyncRequestNotStarted,
+  ASYNC_REQUEST_FAILED_ACTION,
+  ASYNC_REQUEST_LOADED_ACTION,
+  ASYNC_REQUEST_LOADING_ACTION,
+
+  generateAsyncRequestReducer
+} from '../../../utils/asyncRequest';
+import { eventRegistrations } from './actions';
+import { EventRegistrationsReducerState, Registration } from './types';
+
+export const initialEventRegistrationsState: EventRegistrationsReducerState = {
+  eventRegistrations:  AsyncRequestNotStarted<Registration[], any>(),
+}
+
+const eventRegistrationsReducer = generateAsyncRequestReducer<
+  EventRegistrationsReducerState,
+  Registration[],
+  void
+>(eventRegistrations.key);
+
+const reducers = (
+  state: EventRegistrationsReducerState = initialEventRegistrationsState,
+  action: C4CAction,
+): EventRegistrationsReducerState => {
+  switch (action.type) {
+    case ASYNC_REQUEST_LOADING_ACTION:
+    case ASYNC_REQUEST_LOADED_ACTION:
+    case ASYNC_REQUEST_FAILED_ACTION:
+      return {
+        ...state,
+        eventRegistrations: eventRegistrationsReducer(state.eventRegistrations, action),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducers;

--- a/src/containers/eventRSVP/ducks/thunks.ts
+++ b/src/containers/eventRSVP/ducks/thunks.ts
@@ -1,5 +1,5 @@
-import { Registration, EventRegistrationsThunkAction } from './types';
 import { eventRegistrations } from './actions';
+import { EventRegistrationsThunkAction, Registration } from './types';
 
 export const getEventRegistrations = (
   eventId: number,

--- a/src/containers/eventRSVP/ducks/thunks.ts
+++ b/src/containers/eventRSVP/ducks/thunks.ts
@@ -1,0 +1,16 @@
+import { Registration, EventRegistrationsThunkAction } from './types';
+import { eventRegistrations } from './actions';
+
+export const getEventRegistrations = (eventId:number): EventRegistrationsThunkAction<void> => {
+  return (dispatch, getState, { protectedApiClient }) => {
+    dispatch(eventRegistrations.loading());
+    return protectedApiClient
+      .getEventRegistrations(eventId)
+      .then((response: Registration[]) => {
+        dispatch(eventRegistrations.loaded(response));
+      })
+      .catch((error: any) => {
+        dispatch(eventRegistrations.failed(error));
+      });
+  };
+};

--- a/src/containers/eventRSVP/ducks/thunks.ts
+++ b/src/containers/eventRSVP/ducks/thunks.ts
@@ -1,7 +1,9 @@
 import { Registration, EventRegistrationsThunkAction } from './types';
 import { eventRegistrations } from './actions';
 
-export const getEventRegistrations = (eventId:number): EventRegistrationsThunkAction<void> => {
+export const getEventRegistrations = (
+  eventId: number,
+): EventRegistrationsThunkAction<void> => {
   return (dispatch, getState, { protectedApiClient }) => {
     dispatch(eventRegistrations.loading());
     return protectedApiClient

--- a/src/containers/eventRSVP/ducks/types.tsx
+++ b/src/containers/eventRSVP/ducks/types.tsx
@@ -1,0 +1,28 @@
+import { ThunkAction } from 'redux-thunk';
+import { ProtectedApiExtraArgs } from '../../../api/protectedApiClient';
+import { PrivilegeLevel } from '../../../auth/ducks/types';
+import { C4CState } from '../../../store';
+import { AsyncRequest } from '../../../utils/asyncRequest';
+import { EventsRSVPActions } from './actions';
+
+export interface Registration {
+  firstName: string;
+  lastName: string;
+  email: string;
+  userId: number;
+  privilegeLevel: PrivilegeLevel;
+  phoneNumber: string;
+  profilePicture: string | null;
+  photoRelease: boolean;
+}
+
+export type EventRegistrationsReducerState = {
+  eventRegistrations: AsyncRequest<Registration[], any>;
+};
+
+export type EventRegistrationsThunkAction<R> = ThunkAction<
+  R,
+  C4CState,
+  ProtectedApiExtraArgs,
+  EventsRSVPActions
+>;

--- a/src/containers/eventRSVP/ducks/types.tsx
+++ b/src/containers/eventRSVP/ducks/types.tsx
@@ -3,7 +3,7 @@ import { ProtectedApiExtraArgs } from '../../../api/protectedApiClient';
 import { PrivilegeLevel } from '../../../auth/ducks/types';
 import { C4CState } from '../../../store';
 import { AsyncRequest } from '../../../utils/asyncRequest';
-import { EventsRSVPActions } from './actions';
+import { EventRegistrationsActions } from './actions';
 
 export interface Registration {
   firstName: string;
@@ -24,5 +24,5 @@ export type EventRegistrationsThunkAction<R> = ThunkAction<
   R,
   C4CState,
   ProtectedApiExtraArgs,
-  EventsRSVPActions
+  EventRegistrationsActions
 >;

--- a/src/containers/eventRSVP/index.tsx
+++ b/src/containers/eventRSVP/index.tsx
@@ -1,0 +1,100 @@
+import { Alert, Spin, Table } from 'antd';
+import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+import { connect, useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { ContentContainer } from '../../components';
+import { C4CState } from '../../store';
+import {
+  asyncRequestIsComplete,
+  asyncRequestIsFailed,
+  asyncRequestIsLoading,
+} from '../../utils/asyncRequest';
+import { getEventRegistrations } from './ducks/thunks';
+import { EventRegistrationsReducerState } from './ducks/types';
+
+interface EventRSVPProps {
+  readonly registrations: EventRegistrationsReducerState['eventRegistrations'];
+}
+
+const EventRSVP: React.FC<EventRSVPProps> = ({ registrations }) => {
+  const dispatch = useDispatch();
+  const id = parseInt(useParams<{ id: string }>().id);
+
+  useEffect(() => {
+    dispatch(getEventRegistrations(id));
+  });
+
+  const columns = [
+    {
+      title: 'First Name',
+      dataIndex: 'firstName',
+      key: 'firstName',
+    },
+    {
+      title: 'Age',
+      dataIndex: 'lastName',
+      key: 'lastName',
+    },
+    {
+      title: 'Email',
+      dataIndex: 'email',
+      key: 'email',
+    },
+    {
+      title: 'ID',
+      dataIndex: 'userId',
+      key: 'userId',
+    },
+    {
+      title: 'Type',
+      dataIndex: 'privilegeLevel',
+      key: 'privilegeLevel',
+    },
+    {
+      title: 'Phone No.',
+      dataIndex: 'phoneNumber',
+      key: 'phoneNumber',
+    },
+    {
+      title: 'Consent to Photo/Video Release',
+      dataIndex: 'photoRelease',
+      key: 'photoRelease',
+    },
+  ];
+
+  return (
+    <>
+      <Helmet>
+        <title>Event RSVP</title>
+        <meta
+          name="description"
+          content="List of users who have RSVP'ed to this event."
+        />
+      </Helmet>
+      <ContentContainer>
+        {asyncRequestIsComplete(registrations) && (
+          <Table columns={columns} dataSource={registrations.result} />
+        )}
+
+        {asyncRequestIsLoading(registrations) && <Spin />}
+        {asyncRequestIsFailed(registrations) && (
+          <Alert
+            message="Error"
+            description={`There was an error loading registrations:\n${registrations.error}`}
+            type="error"
+            showIcon
+          />
+        )}
+      </ContentContainer>
+    </>
+  );
+};
+
+const mapStateToProps = (state: C4CState): EventRSVPProps => {
+  return {
+    registrations: state.eventRegistrationsState.eventRegistrations,
+  };
+};
+
+export default connect(mapStateToProps)(EventRSVP);

--- a/src/containers/eventRSVP/index.tsx
+++ b/src/containers/eventRSVP/index.tsx
@@ -40,7 +40,7 @@ const EventRSVP: React.FC<EventRSVPProps> = ({ events, registrations }) => {
   useEffect(() => {
     dispatch(getUpcomingEvents());
     dispatch(getEventRegistrations(id));
-  }, [dispatch]);
+  }, [dispatch, id]);
 
   const columns = [
     {

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,16 +24,21 @@ import { AnnouncementsActions } from './containers/announcements/ducks/actions';
 import announcementsReducer, {
   initialAnnouncementsState,
 } from './containers/announcements/ducks/reducers';
-import { PersonalRequestsReducerState } from './containers/personalRequests/ducks/types';
-import { PersonalRequestsActions } from './containers/personalRequests/ducks/actions';
-import personalRequestsReducer, {
-  initialPersonalRequestsState,
-} from './containers/personalRequests/ducks/reducers';
 import { AnnouncementsReducerState } from './containers/announcements/ducks/types';
 import deactivateAccountReducer, {
   initialDeactivateAccountState,
 } from './containers/deactivateAccount/ducks/reducers';
 import { DeactivateAccountReducerState } from './containers/deactivateAccount/ducks/types';
+import { EventRegistrationsActions } from './containers/eventRSVP/ducks/actions';
+import eventRegistrationsReducer, {
+  initialEventRegistrationsState,
+} from './containers/eventRSVP/ducks/reducers';
+import { EventRegistrationsReducerState } from './containers/eventRSVP/ducks/types';
+import { PersonalRequestsActions } from './containers/personalRequests/ducks/actions';
+import personalRequestsReducer, {
+  initialPersonalRequestsState,
+} from './containers/personalRequests/ducks/reducers';
+import { PersonalRequestsReducerState } from './containers/personalRequests/ducks/types';
 import { EventsActions } from './containers/upcoming-events/ducks/actions';
 import eventsReducer, {
   initialEventsState,
@@ -47,6 +52,7 @@ export interface C4CState {
   announcementsState: AnnouncementsReducerState;
   personalRequestsState: PersonalRequestsReducerState;
   deactivateAccountState: DeactivateAccountReducerState;
+  eventRegistrationsState: EventRegistrationsReducerState;
 }
 
 export interface Action<T, P> {
@@ -58,7 +64,8 @@ export type C4CAction =
   | UserAuthenticationActions
   | EventsActions
   | AnnouncementsActions
-  | PersonalRequestsActions;
+  | PersonalRequestsActions
+  | EventRegistrationsActions;
 
 export type ThunkExtraArgs = UserAuthenticationExtraArgs &
   PublicApiExtraArgs &
@@ -70,6 +77,7 @@ const reducers = combineReducers<C4CState, C4CAction>({
   announcementsState: announcementsReducer,
   personalRequestsState: personalRequestsReducer,
   deactivateAccountState: deactivateAccountReducer,
+  eventRegistrationsState: eventRegistrationsReducer,
 });
 
 export const initialStoreState: C4CState = {
@@ -78,6 +86,7 @@ export const initialStoreState: C4CState = {
   announcementsState: initialAnnouncementsState,
   personalRequestsState: initialPersonalRequestsState,
   deactivateAccountState: initialDeactivateAccountState,
+  eventRegistrationsState: initialEventRegistrationsState,
 };
 
 export const LOCALSTORAGE_STATE_KEY = 'state';


### PR DESCRIPTION
## Issue

Closes #42 

## Changes
- Created event registration for admins at `/events/:id/rsvp`
- Created new set of routes for admins in app.tsx
- Created redux for "eventRegistrations" which holds one list of user registration data at a time, subsequent routes will dispatch a new action to load the list of registrations. Since only one list of registrations can be viewed at a time this will work fine.
- Error and loading state handling for the registration page


## Screenshots
![image](https://user-images.githubusercontent.com/23691775/113521145-8d500800-9565-11eb-8a12-890801e62c18.png)


![image](https://user-images.githubusercontent.com/23691775/113521142-86c19080-9565-11eb-9778-6dcd52aa9b93.png)


## Verification Steps

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. 
