### PR TITLE
rename register in appropriate spots

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -55,7 +55,7 @@ const EventsCardComponent: React.FC<EventsCardProps> = ({
 
       <Paragraph ellipsis={{ rows: 3 }}>{description}</Paragraph>
       <LinkButton type="primary" to={to}>
-        Register
+        Learn More
       </LinkButton>
     </EventsCard>
   );

--- a/src/components/event-listing/EventListing.tsx
+++ b/src/components/event-listing/EventListing.tsx
@@ -123,7 +123,7 @@ const EventListing: React.FC<EventListingProps> = ({
               <GrayButton to={BASE_EVENTS_ROUTE + id}>View RSVP</GrayButton>
             </AdminButtonWrapper>
           ) : (
-            <GreenButton to={BASE_EVENTS_ROUTE + id}>Register</GreenButton>
+            <GreenButton to={BASE_EVENTS_ROUTE + id}>Learn More</GreenButton>
           )}
         </Info>
       </CardContent>

--- a/src/components/event-listing/EventListing.tsx
+++ b/src/components/event-listing/EventListing.tsx
@@ -115,7 +115,7 @@ const EventListing: React.FC<EventListingProps> = ({
           <Paragraph ellipsis={{ rows: 5 }}>{details.description}</Paragraph>
           {admin ? (
             <AdminButtonWrapper>
-              <GreenButton to={BASE_EVENTS_ROUTE + id}>Register</GreenButton>
+              <GreenButton to={BASE_EVENTS_ROUTE + id}>Learn More</GreenButton>
               <GreenButton to={BASE_EVENTS_ROUTE + id}>Edit</GreenButton>
               <GreenButton to={BASE_EVENTS_ROUTE + id}>
                 Make Announcement


### PR DESCRIPTION
Looks like EventCard (only used by the home page) and EventListing (used on the events page) are the only two spots that needed the rename.

## Issue

Closes #122 

## Changes

Go to the relevant issue and **tick the items that have been addressed by this PR**. Ensure you cover every item.

Briefly list the changes made to the code:

- Renamed "Register" to "Learn More" on the Home and Events pages

## Screenshots

Home page:
![image](https://user-images.githubusercontent.com/46979800/114798923-82b32100-9d64-11eb-8766-9212525fa2ca.png)

Events page:
![image](https://user-images.githubusercontent.com/46979800/114798955-91013d00-9d64-11eb-864c-c9a605fa62c9.png)

Single event page (remains the same with the "Register" text):
![image](https://user-images.githubusercontent.com/46979800/114798987-a2e2e000-9d64-11eb-9ab7-05b6af092c4d.png)


## Verification Steps

Just looked through all the pages and checked which ones needed the rename.
