### PR TITLE
Added navbar + dropdown links, conditional home page rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,9 @@ export enum Routes {
   CHANGE_ACCOUNT_EMAIL = '/change-email',
   EVENT_REGISTRATIONS = '/events/:id/rsvp',
   FAMILY_DETAILS = '/family-details/:id',
+  CREATE_EVENT = '/create-event',
+  MAKE_ANNOUNCEMENT = '/make-announcement',
+  VIEW_REQUESTS = '/view-requests',
 }
 
 const App: React.FC = () => {

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -25,7 +25,10 @@ import { asyncRequestIsComplete } from '../../utils/asyncRequest';
 import { ORANGE } from '../../utils/colors';
 import LoginModal from '../modals/login-modal/LoginModal';
 import { getRequestStatuses } from '../../containers/personalRequests/ducks/thunks';
-import { PersonalRequestsReducerState } from '../../containers/personalRequests/ducks/types';
+import {
+  PersonalRequest,
+  PersonalRequestsReducerState,
+} from '../../containers/personalRequests/ducks/types';
 
 const { Text } = Typography;
 
@@ -189,6 +192,10 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, personalRequests }) => {
 
   const [displayLoginModal, setDisplayLoginModal] = useState(false);
 
+  const getNumPendingRequests = (requests: PersonalRequest[]) => {
+    return requests.filter((request) => request.status === 'PENDING').length;
+  };
+
   return (
     <>
       <NavBarContainer>
@@ -307,11 +314,9 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, personalRequests }) => {
                       {asyncRequestIsComplete(personalRequests) ? (
                         location.pathname === Routes.VIEW_REQUESTS ? (
                           <Badge
-                            count={
-                              personalRequests.result.filter(
-                                (request) => request.status === 'PENDING',
-                              ).length
-                            }
+                            count={getNumPendingRequests(
+                              personalRequests.result,
+                            )}
                           >
                             <ActiveNavBarButton
                               type="link"
@@ -324,11 +329,9 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, personalRequests }) => {
                           </Badge>
                         ) : (
                           <Badge
-                            count={
-                              personalRequests.result.filter(
-                                (request) => request.status === 'PENDING',
-                              ).length
-                            }
+                            count={getNumPendingRequests(
+                              personalRequests.result,
+                            )}
                           >
                             <NavBarButton
                               tab-index="0"

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,6 +1,15 @@
 import { DownOutlined, UserOutlined } from '@ant-design/icons';
-import { Button, Col, Dropdown, Image, Menu, Row, Typography } from 'antd';
-import React, { useState } from 'react';
+import {
+  Button,
+  Col,
+  Dropdown,
+  Image,
+  Menu,
+  Row,
+  Typography,
+  Badge,
+} from 'antd';
+import React, { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -15,6 +24,8 @@ import { C4CState } from '../../store';
 import { asyncRequestIsComplete } from '../../utils/asyncRequest';
 import { ORANGE } from '../../utils/colors';
 import LoginModal from '../modals/login-modal/LoginModal';
+import { getRequestStatuses } from '../../containers/personalRequests/ducks/thunks';
+import { PersonalRequestsReducerState } from '../../containers/personalRequests/ducks/types';
 
 const { Text } = Typography;
 
@@ -76,9 +87,10 @@ const UserContainer = styled.div`
 
 interface NavBarProps {
   readonly tokens: UserAuthenticationReducerState['tokens'];
+  readonly personalRequests: PersonalRequestsReducerState['personalRequests'];
 }
 
-const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
+const NavBar: React.FC<NavBarProps> = ({ tokens, personalRequests }) => {
   const history = useHistory();
   const location = useLocation();
   const dispatch = useDispatch();
@@ -92,25 +104,66 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
   const authLinks = {
     'My Events': Routes.MY_EVENTS,
   };
+  const adminLinks = {
+    'Create Event': Routes.CREATE_EVENT,
+    'Make Announcement': Routes.MAKE_ANNOUNCEMENT,
+  };
+
+  useEffect(() => {
+    dispatch(getRequestStatuses());
+  }, [dispatch]);
 
   // Dropdown menu options for the logged in
   const userMenu = (
     <Menu>
       <Menu.Item
         onClick={() => {
-          history.push(Routes.CHANGE_ACCOUNT_EMAIL);
+          history.push(Routes.HOME);
         }}
       >
-        Change Primary Account Email
+        Home
       </Menu.Item>
-      <Menu.Item>Account Details</Menu.Item>
-      <Menu.Item>Change Password</Menu.Item>
       <Menu.Item
         onClick={() => {
-          history.push(Routes.DEACTIVATE_ACCOUNT);
+          history.push(Routes.UPCOMING_EVENTS);
         }}
       >
-        Deactivate Account
+        Upcoming Events
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.ANNOUNCEMENTS);
+        }}
+      >
+        Announcements
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.MY_EVENTS);
+        }}
+      >
+        My Events
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.CREATE_EVENT);
+        }}
+      >
+        Create Event
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.MAKE_ANNOUNCEMENT);
+        }}
+      >
+        Make Announcement
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.VIEW_REQUESTS);
+        }}
+      >
+        View Requests
       </Menu.Item>
       <Menu.Item
         onClick={() => {
@@ -118,13 +171,6 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
         }}
       >
         Settings
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.SET_CONTACTS);
-        }}
-      >
-        Update Profile Information
       </Menu.Item>
       <Menu.Item
         onClick={() => {
@@ -229,6 +275,82 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
                     ))}{' '}
                   </>
                 )}
+                {privilegeLevel === PrivilegeLevel.ADMIN && (
+                  <>
+                    {Object.entries(adminLinks).map(([link, path], i) => (
+                      <Col key={i}>
+                        {path === location.pathname ? (
+                          <ActiveNavBarButton
+                            type="link"
+                            onClick={() => {
+                              history.push(path);
+                            }}
+                          >
+                            {link}
+                          </ActiveNavBarButton>
+                        ) : (
+                          <NavBarButton
+                            tab-index="0"
+                            type="link"
+                            onClick={() => {
+                              history.push(path);
+                            }}
+                          >
+                            {link}
+                          </NavBarButton>
+                        )}
+                      </Col>
+                    ))}{' '}
+                    <Col>
+                      {asyncRequestIsComplete(personalRequests) ? (
+                        location.pathname === Routes.VIEW_REQUESTS ? (
+                          <Badge
+                            count={personalRequests.result.filter(
+                              (request) => request.status === 'PENDING',
+                            )}
+                          >
+                            <ActiveNavBarButton
+                              type="link"
+                              onClick={() => {
+                                history.push(Routes.VIEW_REQUESTS);
+                              }}
+                            >
+                              View Requests
+                            </ActiveNavBarButton>
+                          </Badge>
+                        ) : (
+                          <Badge
+                            count={
+                              personalRequests.result.filter(
+                                (request) => request.status === 'PENDING',
+                              ).length
+                            }
+                          >
+                            <NavBarButton
+                              tab-index="0"
+                              type="link"
+                              onClick={() => {
+                                history.push(Routes.VIEW_REQUESTS);
+                              }}
+                            >
+                              View Requests
+                            </NavBarButton>
+                          </Badge>
+                        )
+                      ) : (
+                        <NavBarButton
+                          tab-index="0"
+                          type="link"
+                          onClick={() => {
+                            history.push(Routes.VIEW_REQUESTS);
+                          }}
+                        >
+                          View Requests
+                        </NavBarButton>
+                      )}
+                    </Col>
+                  </>
+                )}
               </Row>
             </Col>
           </Row>
@@ -288,6 +410,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
 const mapStateToProps = (state: C4CState): NavBarProps => {
   return {
     tokens: state.authenticationState.tokens,
+    personalRequests: state.personalRequestsState.personalRequests,
   };
 };
 

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -110,8 +110,10 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, personalRequests }) => {
   };
 
   useEffect(() => {
-    dispatch(getRequestStatuses());
-  }, [dispatch]);
+    if (asyncRequestIsComplete(tokens)) {
+      dispatch(getRequestStatuses());
+    }
+  }, [dispatch, tokens]);
 
   // Dropdown menu options for the logged in
   const userMenu = (
@@ -305,9 +307,11 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, personalRequests }) => {
                       {asyncRequestIsComplete(personalRequests) ? (
                         location.pathname === Routes.VIEW_REQUESTS ? (
                           <Badge
-                            count={personalRequests.result.filter(
-                              (request) => request.status === 'PENDING',
-                            )}
+                            count={
+                              personalRequests.result.filter(
+                                (request) => request.status === 'PENDING',
+                              ).length
+                            }
                           >
                             <ActiveNavBarButton
                               type="link"

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -1,8 +1,11 @@
 import { Card, Col, Row, Typography } from 'antd';
 import { default as React, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { Routes } from '../../App';
+import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { PrivilegeLevel } from '../../auth/ducks/types';
 import AnnouncementsList from '../../components/announcementsList';
 import EventCard from '../../components/EventCard';
 import { LinkButton } from '../../components/LinkButton';
@@ -31,15 +34,6 @@ const LandingContainer = styled.div`
   background-position: center; /* Center the image */
   background-repeat: no-repeat; /* Do not repeat the image */
   background-size: cover; /* Resize the background image to cover the entire container */
-`;
-const LandingCard = styled(Card)`
-  position: relative;
-  top: 30%;
-  left: 15%;
-  width: 500px;
-  height: 280px;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-  border-radius: 5px;
 `;
 
 const LandingText = styled(Text)`
@@ -76,6 +70,10 @@ const ViewMoreButton = styled(LinkButton)`
   margin: 1em;
 `;
 
+const AdminCol = styled(Col)`
+  text-align: center;
+`;
+
 const CARD_ROW_LIMIT = 3;
 
 export interface HomeContainerProps {
@@ -85,6 +83,9 @@ export interface HomeContainerProps {
 
 const Home: React.FC<HomeContainerProps> = ({ events, announcements }) => {
   const dispatch = useDispatch();
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) => {
+    return getPrivilegeLevel(state.authenticationState.tokens);
+  });
 
   useEffect(() => {
     dispatch(getAnnouncements());
@@ -94,6 +95,16 @@ const Home: React.FC<HomeContainerProps> = ({ events, announcements }) => {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
+  const LandingCard = styled(Card)`
+    position: relative;
+    top: 30%;
+    left: 15%;
+    width: ${privilegeLevel === PrivilegeLevel.ADMIN ? '600px' : '500px'};
+    height: ${privilegeLevel === PrivilegeLevel.ADMIN ? '250px' : '280px'};
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border-radius: 5px;
+  `;
   return (
     <>
       <Helmet>
@@ -104,22 +115,54 @@ const Home: React.FC<HomeContainerProps> = ({ events, announcements }) => {
         />
       </Helmet>
 
-      <LandingContainer>
-        <LandingCard bordered={false}>
-          <LandingTextContainer>
-            <LandingText>
-              Welcome to Lucy's Love Bus Event Registration!
-            </LandingText>
-          </LandingTextContainer>
-          <LandingBodyText>
-            The Sajni Center invites you to use this page as your portal to view
-            and register for events, and stay up to date with our community!
-          </LandingBodyText>
-          <LinkButton type="primary" to="/upcoming-events">
-            View Events
-          </LinkButton>
-        </LandingCard>
-      </LandingContainer>
+      {privilegeLevel === PrivilegeLevel.ADMIN ? (
+        <LandingContainer>
+          <LandingCard bordered={false}>
+            <LandingTextContainer>
+              <LandingText>Welcome Administrator!</LandingText>
+            </LandingTextContainer>
+            <LandingBodyText>
+              Explore and use these tools to help create a space of hope and
+              healing for the members of The Sajni Center.
+            </LandingBodyText>
+            <Row>
+              <AdminCol span={8}>
+                <LinkButton type="primary" to={Routes.CREATE_EVENT}>
+                  Create Event
+                </LinkButton>
+              </AdminCol>
+              <AdminCol span={8}>
+                <LinkButton type="primary" to={Routes.MAKE_ANNOUNCEMENT}>
+                  Make Announcement
+                </LinkButton>
+              </AdminCol>
+              <AdminCol span={8}>
+                <LinkButton type="primary" to={Routes.VIEW_REQUESTS}>
+                  View Requests
+                </LinkButton>
+              </AdminCol>
+            </Row>
+          </LandingCard>
+        </LandingContainer>
+      ) : (
+        <LandingContainer>
+          <LandingCard bordered={false}>
+            <LandingTextContainer>
+              <LandingText>
+                Welcome to Lucy's Love Bus Event Registration!
+              </LandingText>
+            </LandingTextContainer>
+            <LandingBodyText>
+              The Sajni Center invites you to use this page as your portal to
+              view and register for events, and stay up to date with our
+              community!
+            </LandingBodyText>
+            <LinkButton type="primary" to="/upcoming-events">
+              View Events
+            </LinkButton>
+          </LandingCard>
+        </LandingContainer>
+      )}
       <HomeContainer>
         <Row align="middle">
           <UpcomingEventsTitle>Upcoming Events</UpcomingEventsTitle>

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -71,7 +71,7 @@ const ViewMoreButton = styled(LinkButton)`
 `;
 
 const AdminCol = styled(Col)`
-  text-align: center;
+  margin-right: 10px;
 `;
 
 const CARD_ROW_LIMIT = 3;
@@ -126,17 +126,17 @@ const Home: React.FC<HomeContainerProps> = ({ events, announcements }) => {
               healing for the members of The Sajni Center.
             </LandingBodyText>
             <Row>
-              <AdminCol span={8}>
+              <AdminCol>
                 <LinkButton type="primary" to={Routes.CREATE_EVENT}>
                   Create Event
                 </LinkButton>
               </AdminCol>
-              <AdminCol span={8}>
+              <AdminCol>
                 <LinkButton type="primary" to={Routes.MAKE_ANNOUNCEMENT}>
                   Make Announcement
                 </LinkButton>
               </AdminCol>
-              <AdminCol span={8}>
+              <AdminCol>
                 <LinkButton type="primary" to={Routes.VIEW_REQUESTS}>
                   View Requests
                 </LinkButton>

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -101,7 +101,7 @@ const Home: React.FC<HomeContainerProps> = ({ events, announcements }) => {
     top: 30%;
     left: 15%;
     width: ${privilegeLevel === PrivilegeLevel.ADMIN ? '600px' : '500px'};
-    height: ${privilegeLevel === PrivilegeLevel.ADMIN ? '250px' : '280px'};
+    height: ${privilegeLevel === PrivilegeLevel.ADMIN ? '220px' : '280px'};
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     border-radius: 5px;
   `;


### PR DESCRIPTION
## Issue

Closes #88

## Changes

- Added the admin navbar and dropdown links for only admins
- Added badge on View Requests that tells the admin how many pending requests there are currently
- Adjusted the dropdown to only have a settings link, as we earlier discussed that the individual links would go on the setting page
- If user is admin, they will see different landing page card on home page
- Added routes that do not have pages yet

## Screenshots

Admin home page view: 
![image](https://user-images.githubusercontent.com/46979800/115125437-099b1000-9f96-11eb-89dd-27540c134ed5.png)

## Verification Steps

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. 

- Checked both versions of the home page by changing my privilege level in my local db