### PR TITLE
Added Bug Report Sticky Footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import styled from 'styled-components';
 import { getPrivilegeLevel } from './auth/ducks/selectors';
 import { PrivilegeLevel } from './auth/ducks/types';
+import BugReportFooter from './components/BugReportFooter';
 import NavBar from './components/navbar';
 import Announcements from './containers/announcements';
 import ChangeAccountEmail from './containers/changeAccountEmail';
@@ -263,6 +264,7 @@ const App: React.FC = () => {
             })()}
           </Content>
         </AppInnerContainer>
+        <BugReportFooter />
       </Router>
     </>
   );

--- a/src/components/BugReportFooter.tsx
+++ b/src/components/BugReportFooter.tsx
@@ -2,19 +2,24 @@ import { BugOutlined } from '@ant-design/icons';
 import { Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
+import { PRIMARY } from '../utils/colors';
 const { Text, Link } = Typography;
 const LittleBugIcon = styled(BugOutlined)`
   margin: 3px;
+  margin-right: 6px;
+  color: ${PRIMARY};
 `;
 const StickyFooter = styled.footer`
   position: fixed;
   left: 0;
   bottom: 0;
-  height: 25px;
+  height: 30px;
   width: 100%;
   display: flex;
   justify-content: center;
   background-color: rgba(255, 255, 255, 0.95);
+  border-top: 1px lightgray solid;
+  padding-top: 5px;
 `;
 
 const BugReportFooter: React.FC = () => {
@@ -22,9 +27,9 @@ const BugReportFooter: React.FC = () => {
     <StickyFooter>
       <LittleBugIcon />{' '}
       <Text>
-        Notice something off?{' '}
+        Notice an issue with the site?{' '}
         <Link href="https://docs.google.com/forms/d/e/1FAIpQLSdaAuvzDfV4fb_SDbsfY3TSTwHKAyDa5dMgTnr1okE9COUTdA/viewform">
-          Submit a Bug Report!
+          Let us know!
         </Link>
       </Text>
     </StickyFooter>

--- a/src/components/BugReportFooter.tsx
+++ b/src/components/BugReportFooter.tsx
@@ -1,0 +1,34 @@
+import { BugOutlined } from '@ant-design/icons';
+import { Typography } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+const { Text, Link } = Typography;
+const LittleBugIcon = styled(BugOutlined)`
+  margin: 3px;
+`;
+const StickyFooter = styled.footer`
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  height: 25px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.95);
+`;
+
+const BugReportFooter: React.FC = () => {
+  return (
+    <StickyFooter>
+      <LittleBugIcon />{' '}
+      <Text>
+        Notice something off?{' '}
+        <Link href="https://docs.google.com/forms/d/e/1FAIpQLSdaAuvzDfV4fb_SDbsfY3TSTwHKAyDa5dMgTnr1okE9COUTdA/viewform">
+          Submit a Bug Report!
+        </Link>
+      </Text>
+    </StickyFooter>
+  );
+};
+
+export default BugReportFooter;


### PR DESCRIPTION
## Issue

Closes #128 

## Changes



- Added a footer to the site that links to the LLB bug report form

## Screenshots

![image](https://user-images.githubusercontent.com/23691775/115128124-93a0a400-9fa9-11eb-88fb-cc5c45f90011.png)

And its sticky too! (plus a little translucent)

![image](https://user-images.githubusercontent.com/23691775/115128136-a1562980-9fa9-11eb-8078-cfbabc933ae3.png)

