### PR TITLE
Settings Hub Page and Better User Dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { PrivilegeLevel } from './auth/ducks/types';
 import NavBar from './components/navbar';
 import Announcements from './containers/announcements';
 import ChangeAccountEmail from './containers/changeAccountEmail';
+import ChangePassword from './containers/changePassword';
 import DeactivateAccount from './containers/deactivateAccount';
 import EventRSVP from './containers/eventRSVP';
 import FamilyDetails from './containers/familyDetails';
@@ -52,6 +53,7 @@ export enum Routes {
   SET_CONTACTS = '/set-contacts',
   SIGNUP_CONFIRMATION = '/signup/confirmation',
   CHANGE_ACCOUNT_EMAIL = '/change-email',
+  CHANGE_PASSWORD = '/change-password',
   EVENT_REGISTRATIONS = '/events/:id/rsvp',
   FAMILY_DETAILS = '/family-details/:id',
 }
@@ -140,6 +142,16 @@ const App: React.FC = () => {
                         exact
                         component={MyEvents}
                       />
+                      <Route
+                        path={Routes.CHANGE_ACCOUNT_EMAIL}
+                        exact
+                        component={ChangeAccountEmail}
+                      />
+                      <Route
+                        path={Routes.CHANGE_PASSWORD}
+                        exact
+                        component={ChangePassword}
+                      />
                       <Route path="*" exact component={NotFound} />
                     </Switch>
                   );
@@ -207,6 +219,11 @@ const App: React.FC = () => {
                         path={Routes.CHANGE_ACCOUNT_EMAIL}
                         exact
                         component={ChangeAccountEmail}
+                      />
+                      <Route
+                        path={Routes.CHANGE_PASSWORD}
+                        exact
+                        component={ChangePassword}
                       />
                       <Route path="*" exact component={NotFound} />
                     </Switch>

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -247,7 +247,6 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, contacts }) => {
                 <UserDropdown overlay={userMenu}>
                   <Button>
                     <UserAvatar
-                      // size="large"
                       src={
                         asyncRequestIsComplete(contacts) &&
                         contacts.result.mainContact.profilePicture

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -254,7 +254,13 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, contacts }) => {
                       }
                       icon={<UserOutlined />}
                     />
-                    <Text>Ryan Jung</Text>
+                    <Text>
+                      {asyncRequestIsComplete(contacts)
+                        ? contacts.result.mainContact.firstName +
+                          ' ' +
+                          contacts.result.mainContact.lastName
+                        : 'Loading...'}
+                    </Text>
                     <DownOutlined />
                   </Button>
                 </UserDropdown>

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -109,7 +109,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, contacts }) => {
     if (asyncRequestIsComplete(tokens)) {
       dispatch(getContactInfo());
     }
-  }, [dispatch]);
+  }, [dispatch, tokens]);
 
   const privilegeLevel: PrivilegeLevel = getPrivilegeLevel(tokens);
   const links = {
@@ -247,7 +247,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens, contacts }) => {
                 <UserDropdown overlay={userMenu}>
                   <Button>
                     <UserAvatar
-                      //size="large"
+                      // size="large"
                       src={
                         asyncRequestIsComplete(contacts) &&
                         contacts.result.mainContact.profilePicture

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,6 +1,15 @@
 import { DownOutlined, UserOutlined } from '@ant-design/icons';
-import { Button, Col, Dropdown, Image, Menu, Row, Typography } from 'antd';
-import React, { useState } from 'react';
+import {
+  Avatar,
+  Button,
+  Col,
+  Dropdown,
+  Image,
+  Menu,
+  Row,
+  Typography,
+} from 'antd';
+import React, { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -11,6 +20,8 @@ import {
   PrivilegeLevel,
   UserAuthenticationReducerState,
 } from '../../auth/ducks/types';
+import { getContactInfo } from '../../containers/setContacts/ducks/thunks';
+import { ContactsReducerState } from '../../containers/setContacts/ducks/types';
 import { C4CState } from '../../store';
 import { asyncRequestIsComplete } from '../../utils/asyncRequest';
 import { ORANGE } from '../../utils/colors';
@@ -74,14 +85,31 @@ const UserContainer = styled.div`
   margin-right: 16px;
 `;
 
+const UserMenu = styled(Menu)`
+  min-width: 100px;
+`;
+const UserDropdown = styled(Dropdown)`
+  min-height: 50px;
+`;
+const UserAvatar = styled(Avatar)`
+  margin-right: 10px;
+`;
+
 interface NavBarProps {
   readonly tokens: UserAuthenticationReducerState['tokens'];
+  readonly contacts: ContactsReducerState['contacts'];
 }
 
-const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
+const NavBar: React.FC<NavBarProps> = ({ tokens, contacts }) => {
   const history = useHistory();
   const location = useLocation();
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (asyncRequestIsComplete(tokens)) {
+      dispatch(getContactInfo());
+    }
+  }, [dispatch]);
 
   const privilegeLevel: PrivilegeLevel = getPrivilegeLevel(tokens);
   const links = {
@@ -95,23 +123,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
 
   // Dropdown menu options for the logged in
   const userMenu = (
-    <Menu>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.CHANGE_ACCOUNT_EMAIL);
-        }}
-      >
-        Change Primary Account Email
-      </Menu.Item>
-      <Menu.Item>Account Details</Menu.Item>
-      <Menu.Item>Change Password</Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.DEACTIVATE_ACCOUNT);
-        }}
-      >
-        Deactivate Account
-      </Menu.Item>
+    <UserMenu>
       <Menu.Item
         onClick={() => {
           history.push(Routes.SETTINGS);
@@ -119,13 +131,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
       >
         Settings
       </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.SET_CONTACTS);
-        }}
-      >
-        Update Profile Information
-      </Menu.Item>
+
       <Menu.Item
         onClick={() => {
           if (asyncRequestIsComplete(tokens)) {
@@ -136,7 +142,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
       >
         Log Out
       </Menu.Item>
-    </Menu>
+    </UserMenu>
   );
 
   const [displayLoginModal, setDisplayLoginModal] = useState(false);
@@ -238,12 +244,20 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
           <Row gutter={[8, 0]}>
             {privilegeLevel !== PrivilegeLevel.NONE ? (
               <Col>
-                <Dropdown overlay={userMenu}>
+                <UserDropdown overlay={userMenu}>
                   <Button>
-                    <UserOutlined />
+                    <UserAvatar
+                      //size="large"
+                      src={
+                        asyncRequestIsComplete(contacts) &&
+                        contacts.result.mainContact.profilePicture
+                      }
+                      icon={<UserOutlined />}
+                    />
+                    <Text>Ryan Jung</Text>
                     <DownOutlined />
                   </Button>
-                </Dropdown>
+                </UserDropdown>
               </Col>
             ) : (
               <>
@@ -288,6 +302,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
 const mapStateToProps = (state: C4CState): NavBarProps => {
   return {
     tokens: state.authenticationState.tokens,
+    contacts: state.contactsState.contacts,
   };
 };
 

--- a/src/containers/changePassword/index.tsx
+++ b/src/containers/changePassword/index.tsx
@@ -16,8 +16,11 @@ const ChangePassword: React.FC = () => {
   return (
     <>
       <Helmet>
-        <title>Settings</title>
-        <meta name="description" content="Description goes here." />
+        <title>Change Password</title>
+        <meta
+          name="description"
+          content="Change your password for Lucy's Love Bus programs."
+        />
       </Helmet>
       <ContentContainer>
         <Title>Settings</Title>

--- a/src/containers/changePassword/index.tsx
+++ b/src/containers/changePassword/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { Button, Form, Input, Typography } from 'antd';
+import ProtectedApiClient from '../../api/protectedApiClient';
+import { ContentContainer } from '../../components';
+
+const { Title } = Typography;
+
+const ChangePassword: React.FC = () => {
+  const onFinishChangePassword = (values: any) => {
+    ProtectedApiClient.changePassword(values)
+      .then((res) => res)
+      .catch((e) => e);
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title>Settings</title>
+        <meta name="description" content="Description goes here." />
+      </Helmet>
+      <ContentContainer>
+        <Title>Settings</Title>
+
+        <Form name="basic" onFinish={onFinishChangePassword}>
+          <Form.Item
+            label="Current Password"
+            name="currentPassword"
+            rules={[
+              {
+                required: true,
+                message: 'Please input your current password!',
+              },
+            ]}
+          >
+            <Input.Password />
+          </Form.Item>
+          <Form.Item
+            label="New Password"
+            name="newPassword"
+            rules={[
+              { required: true, message: 'Please input your new password!' },
+            ]}
+          >
+            <Input.Password />
+          </Form.Item>
+          <Form.Item
+            name="confirm"
+            label="Confirm Password"
+            dependencies={['newPassword']}
+            hasFeedback
+            rules={[
+              {
+                required: true,
+                message: 'Please confirm your password!',
+              },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue('password') === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(
+                    'The two passwords that you entered do not match!',
+                  );
+                },
+              }),
+            ]}
+          >
+            <Input.Password />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit">
+              Change Password
+            </Button>
+          </Form.Item>
+        </Form>
+      </ContentContainer>
+    </>
+  );
+};
+
+export default ChangePassword;

--- a/src/containers/settings/index.tsx
+++ b/src/containers/settings/index.tsx
@@ -1,79 +1,73 @@
+import {
+  EditOutlined,
+  ExclamationCircleOutlined,
+  KeyOutlined,
+  MailOutlined,
+  UsergroupAddOutlined,
+} from '@ant-design/icons';
+import { Typography } from 'antd';
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { Button, Form, Input, Typography } from 'antd';
-import ProtectedApiClient from '../../api/protectedApiClient';
+import styled from 'styled-components';
+import { Routes } from '../../App';
 import { ContentContainer } from '../../components';
+import { LinkButton } from '../../components/LinkButton';
+import { ORANGE } from '../../utils/colors';
 
 const { Title } = Typography;
+const CenteredOrangeTitle = styled.h1`
+  text-align: center;
+  font-weight: 800;
+  font-size: 2em;
+  color: ${ORANGE};
+`;
+
+const CenteredButtonContainer = styled.div`
+  display: block;
+  max-width: 400px;
+  margin: auto;
+`;
+
+const SettingsButton = styled(LinkButton)`
+  width: 100%;
+  min-height: 3rem;
+  margin-bottom: 1rem;
+`;
 
 const Settings: React.FC = () => {
-  const onFinishChangePassword = (values: any) => {
-    ProtectedApiClient.changePassword(values)
-      .then((res) => res)
-      .catch((e) => e);
-  };
-
   return (
     <>
       <Helmet>
         <title>Settings</title>
-        <meta name="description" content="Description goes here." />
+        <meta
+          name="description"
+          content="Settings for Lucy's Love Bus Programs account."
+        />
       </Helmet>
       <ContentContainer>
-        <Title>Settings</Title>
-
-        <Form name="basic" onFinish={onFinishChangePassword}>
-          <Form.Item
-            label="Current Password"
-            name="currentPassword"
-            rules={[
-              {
-                required: true,
-                message: 'Please input your current password!',
-              },
-            ]}
-          >
-            <Input.Password />
-          </Form.Item>
-          <Form.Item
-            label="New Password"
-            name="newPassword"
-            rules={[
-              { required: true, message: 'Please input your new password!' },
-            ]}
-          >
-            <Input.Password />
-          </Form.Item>
-          <Form.Item
-            name="confirm"
-            label="Confirm Password"
-            dependencies={['newPassword']}
-            hasFeedback
-            rules={[
-              {
-                required: true,
-                message: 'Please confirm your password!',
-              },
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value || getFieldValue('password') === value) {
-                    return Promise.resolve();
-                  }
-                  return Promise.reject(
-                    'The two passwords that you entered do not match!',
-                  );
-                },
-              }),
-            ]}
-          >
-            <Input.Password />
-          </Form.Item>
-          <Form.Item>
-            <Button type="primary" htmlType="submit">
-              Change Password
-            </Button>
-          </Form.Item>
-        </Form>
+        <CenteredOrangeTitle>Settings</CenteredOrangeTitle>
+        <CenteredButtonContainer>
+          <SettingsButton to={Routes.CHANGE_ACCOUNT_EMAIL}>
+            Change Primary Account Email
+            <MailOutlined />
+          </SettingsButton>
+          <SettingsButton to={Routes.CHANGE_PASSWORD}>
+            Change Password
+            <KeyOutlined />
+          </SettingsButton>
+          <SettingsButton to={Routes.SET_CONTACTS}>
+            Edit Account Information
+            <EditOutlined />
+          </SettingsButton>
+          <SettingsButton to={Routes.PERSONAL_REQUESTS}>
+            Request to Become a Participating Family
+            <UsergroupAddOutlined />
+          </SettingsButton>
+          <SettingsButton to={Routes.DEACTIVATE_ACCOUNT}>
+            Deactivate Account
+            <ExclamationCircleOutlined />
+          </SettingsButton>
+        </CenteredButtonContainer>
       </ContentContainer>
     </>
   );

--- a/src/containers/settings/index.tsx
+++ b/src/containers/settings/index.tsx
@@ -5,7 +5,6 @@ import {
   MailOutlined,
   UsergroupAddOutlined,
 } from '@ant-design/icons';
-import { Typography } from 'antd';
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import styled from 'styled-components';
@@ -14,7 +13,6 @@ import { ContentContainer } from '../../components';
 import { LinkButton } from '../../components/LinkButton';
 import { ORANGE } from '../../utils/colors';
 
-const { Title } = Typography;
 const CenteredOrangeTitle = styled.h1`
   text-align: center;
   font-weight: 800;


### PR DESCRIPTION
## Issue

Closes #96 

## Changes
- Added settings hub page that redirects to other pages
- Removed other settings pages from dropdown, replaced with link to settings hub
- Added profile picture and name to user dropdown
- Loads profile picture, first, and last name on navbar

## Screenshots

Settings page + updated dropdown
![image](https://user-images.githubusercontent.com/23691775/115130019-c9e61f80-9fb9-11eb-8225-3a88006ebd3b.png)

Dropdown, no profile picture
![image](https://user-images.githubusercontent.com/23691775/115130017-c6529880-9fb9-11eb-9502-9d098649ae69.png)

Dropdown with menu items

![image](https://user-images.githubusercontent.com/23691775/115130211-a328e880-9fbb-11eb-875f-29f84d97d128.png)
Provide screenshots of any new components, styling changes, or pages. 

## Verification Steps

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. 
