### PR TITLE
Clear In-Memory Redux Store on Logout

### DIFF
--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -131,6 +131,7 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
           if (asyncRequestIsComplete(tokens)) {
             dispatch(logout());
             history.push(Routes.HOME);
+            history.go(0);
           }
         }}
       >


### PR DESCRIPTION
## Issue

Closes #132 

## Changes
- Force refresh on logout to clear in-memory redux store, localstorage redux store is already cleared on logout
