### PR TITLE
Admin Approve PF Requests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import SingleEvent from './containers/singleEvent';
 import UpcomingEvents from './containers/upcoming-events';
 import VerifyEmail from './containers/verifyEmail';
 import ViewRequests from './containers/viewRequests';
+import ViewSingleRequest from './containers/viewSingleRequest'
 import { C4CState } from './store';
 
 const { Content } = Layout;
@@ -56,6 +57,7 @@ export enum Routes {
   EVENT_REGISTRATIONS = '/events/:id/rsvp',
   FAMILY_DETAILS = '/family-details/:id',
   VIEW_REQUESTS = '/view-requests',
+  VIEW_PF_REQUEST = '/view-request/:id',
 }
 
 const App: React.FC = () => {
@@ -146,6 +148,11 @@ const App: React.FC = () => {
                         path={Routes.VIEW_REQUESTS}
                         exact
                         component={ViewRequests}
+                      />
+                      <Route
+                        path={Routes.VIEW_PF_REQUEST}
+                        exact
+                        component={ViewSingleRequest}
                       />
                       <Route path="*" exact component={NotFound} />
                     </Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ export enum Routes {
   EVENT_REGISTRATIONS = '/events/:id/rsvp',
   FAMILY_DETAILS = '/family-details/:id',
   VIEW_REQUESTS = '/view-requests',
-  VIEW_PF_REQUEST = '/view-request/:id',
+  VIEW_PF_REQUEST = '/view-request/:request_id/:user-id',
 }
 
 const App: React.FC = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import SignupFormContainer from './containers/signupForm';
 import SingleEvent from './containers/singleEvent';
 import UpcomingEvents from './containers/upcoming-events';
 import VerifyEmail from './containers/verifyEmail';
+import ViewRequests from './containers/viewRequests';
 import { C4CState } from './store';
 
 const { Content } = Layout;
@@ -54,6 +55,7 @@ export enum Routes {
   CHANGE_ACCOUNT_EMAIL = '/change-email',
   EVENT_REGISTRATIONS = '/events/:id/rsvp',
   FAMILY_DETAILS = '/family-details/:id',
+  VIEW_REQUESTS = '/view-requests',
 }
 
 const App: React.FC = () => {
@@ -139,6 +141,11 @@ const App: React.FC = () => {
                         path={Routes.MY_EVENTS}
                         exact
                         component={MyEvents}
+                      />
+                      <Route
+                        path={Routes.VIEW_REQUESTS}
+                        exact
+                        component={ViewRequests}
                       />
                       <Route path="*" exact component={NotFound} />
                     </Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import SingleEvent from './containers/singleEvent';
 import UpcomingEvents from './containers/upcoming-events';
 import VerifyEmail from './containers/verifyEmail';
 import ViewRequests from './containers/viewRequests';
-import ViewSingleRequest from './containers/viewSingleRequest'
+import ViewSingleRequest from './containers/viewSingleRequest';
 import { C4CState } from './store';
 
 const { Content } = Layout;
@@ -57,7 +57,7 @@ export enum Routes {
   EVENT_REGISTRATIONS = '/events/:id/rsvp',
   FAMILY_DETAILS = '/family-details/:id',
   VIEW_REQUESTS = '/view-requests',
-  VIEW_PF_REQUEST = '/view-request/:request_id/:user_id',
+  VIEW_PF_REQUEST = '/view-request/:request_id',
 }
 
 const App: React.FC = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ export enum Routes {
   EVENT_REGISTRATIONS = '/events/:id/rsvp',
   FAMILY_DETAILS = '/family-details/:id',
   VIEW_REQUESTS = '/view-requests',
-  VIEW_PF_REQUEST = '/view-request/:request_id/:user-id',
+  VIEW_PF_REQUEST = '/view-request/:request_id/:user_id',
 }
 
 const App: React.FC = () => {

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -50,6 +50,9 @@ export interface ProtectedApiClient {
   readonly getPFRequests: () => Promise<PFRequestResponse>;
   readonly approvePFRequest: (requestId: number) => Promise<void>;
   readonly denyPFRequest: (requestId: number) => Promise<void>;
+  readonly getRequestContactInfoById: (
+    requestId: number,
+  ) => Promise<ContactInfo>;
   readonly deactivateAccount: () => Promise<void>;
   readonly getEventAnnouncements: (
     eventId: number,
@@ -161,6 +164,12 @@ const denyPFRequest = (requestId: number): Promise<void> => {
   );
 };
 
+const getRequestContactInfoById = (requestId: number): Promise<ContactInfo> => {
+  return AppAxiosInstance.get(
+    `${ProtectedApiClientRoutes.PF_REQUESTS}/${requestId}`,
+  ).then((res) => res.data);
+};
+
 const getEventAnnouncements = (
   eventId: number,
 ): Promise<EventAnnouncement[]> => {
@@ -192,6 +201,7 @@ const Client: ProtectedApiClient = Object.freeze({
   getPFRequests,
   approvePFRequest,
   denyPFRequest,
+  getRequestContactInfoById,
   deactivateAccount,
   getEventAnnouncements,
   getContactInfo,

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -6,6 +6,25 @@ import { EventAnnouncement } from '../containers/singleEvent/ducks/types';
 import { ContactInfo } from '../containers/setContacts/ducks/types';
 import { EventInformation } from '../containers/upcoming-events/ducks/types';
 
+export interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+}
+
+export interface PFRequest {
+  id: string;
+  user: User;
+}
+
+export interface PFRequestResponse {
+  data: {
+      requests: PFRequest[]
+  };
+}
+
 interface LineItem {
   eventId: number;
   quantity: number;
@@ -28,6 +47,7 @@ export interface ProtectedApiClient {
   readonly getMyEvents: () => Promise<EventInformation[]>;
   readonly getRequestStatuses: () => Promise<PersonalRequest[]>;
   readonly makePFRequest: () => Promise<void>;
+  readonly getPFRequests: () => Promise<PFRequestResponse>;
   readonly deactivateAccount: () => Promise<void>;
   readonly getEventAnnouncements: (
     eventId: number,
@@ -44,7 +64,7 @@ export enum ProtectedApiClientRoutes {
   REGISTER_TICKETS = '/api/v1/protected/checkout/register',
   MY_EVENTS = '/api/v1/protected/events/signed_up',
   REQUEST_STATUSES = '/api/v1/protected/requests/status',
-  MAKE_PF_REQUEST = 'api/v1/protected/requests',
+  PF_REQUESTS = 'api/v1/protected/requests',
   USER = '/api/v1/protected/user',
   ANNOUNCEMENTS = 'api/v1/protected/announcements',
   CONTACT_INFO = '/api/v1/protected/user/contact_info',
@@ -78,6 +98,7 @@ const getMyEvents = (): Promise<EventInformation[]> => {
     (res) => res.data.events,
   );
 };
+
 const deactivateAccount = (): Promise<void> => {
   return AppAxiosInstance.delete(ProtectedApiClientRoutes.USER)
     .then((res) => res)
@@ -107,11 +128,15 @@ const getRequestStatuses = (): Promise<PersonalRequest[]> => {
 };
 
 const makePFRequest = (): Promise<void> => {
-  return AppAxiosInstance.post(ProtectedApiClientRoutes.MAKE_PF_REQUEST)
+  return AppAxiosInstance.post(ProtectedApiClientRoutes.PF_REQUESTS)
     .then((res) => {
       return;
     })
     .catch((err) => err);
+};
+
+const getPFRequests = (): Promise<PFRequestResponse> => {
+  return AppAxiosInstance.get(ProtectedApiClientRoutes.PF_REQUESTS);
 };
 
 const getEventAnnouncements = (
@@ -142,6 +167,7 @@ const Client: ProtectedApiClient = Object.freeze({
   getMyEvents,
   getRequestStatuses,
   makePFRequest,
+  getPFRequests,
   deactivateAccount,
   getEventAnnouncements,
   getContactInfo,

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -21,7 +21,7 @@ export interface PFRequest {
 
 export interface PFRequestResponse {
   data: {
-      requests: PFRequest[]
+    requests: PFRequest[];
   };
 }
 
@@ -48,6 +48,8 @@ export interface ProtectedApiClient {
   readonly getRequestStatuses: () => Promise<PersonalRequest[]>;
   readonly makePFRequest: () => Promise<void>;
   readonly getPFRequests: () => Promise<PFRequestResponse>;
+  readonly approvePFRequest: (requestId: number) => Promise<void>;
+  readonly denyPFRequest: (requestId: number) => Promise<void>;
   readonly deactivateAccount: () => Promise<void>;
   readonly getEventAnnouncements: (
     eventId: number,
@@ -65,6 +67,8 @@ export enum ProtectedApiClientRoutes {
   MY_EVENTS = '/api/v1/protected/events/signed_up',
   REQUEST_STATUSES = '/api/v1/protected/requests/status',
   PF_REQUESTS = 'api/v1/protected/requests',
+  APPROVE_PF_REQUEST = 'api/v1/protected/requests/:request_id/approve',
+  DENY_PF_REQUEST = 'api/v1/protected/requests/:request_id/reject',
   USER = '/api/v1/protected/user',
   ANNOUNCEMENTS = 'api/v1/protected/announcements',
   CONTACT_INFO = '/api/v1/protected/user/contact_info',
@@ -139,6 +143,24 @@ const getPFRequests = (): Promise<PFRequestResponse> => {
   return AppAxiosInstance.get(ProtectedApiClientRoutes.PF_REQUESTS);
 };
 
+const approvePFRequest = (requestId: number): Promise<void> => {
+  return AppAxiosInstance.post(
+    ProtectedApiClientRoutes.APPROVE_PF_REQUEST.replace(
+      ':request_id',
+      String(requestId),
+    ),
+  );
+};
+
+const denyPFRequest = (requestId: number): Promise<void> => {
+  return AppAxiosInstance.post(
+    ProtectedApiClientRoutes.DENY_PF_REQUEST.replace(
+      ':request_id',
+      String(requestId),
+    ),
+  );
+};
+
 const getEventAnnouncements = (
   eventId: number,
 ): Promise<EventAnnouncement[]> => {
@@ -168,6 +190,8 @@ const Client: ProtectedApiClient = Object.freeze({
   getRequestStatuses,
   makePFRequest,
   getPFRequests,
+  approvePFRequest,
+  denyPFRequest,
   deactivateAccount,
   getEventAnnouncements,
   getContactInfo,

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -23,9 +23,7 @@ export interface PFRequest {
 }
 
 export interface PFRequestResponse {
-  data: {
-    requests: PFRequest[];
-  };
+  requests: PFRequest[];
 }
 
 interface LineItem {
@@ -166,7 +164,9 @@ const makePFRequest = (): Promise<void> => {
 };
 
 const getPFRequests = (): Promise<PFRequestResponse> => {
-  return AppAxiosInstance.get(ProtectedApiClientRoutes.PF_REQUESTS);
+  return AppAxiosInstance.get(ProtectedApiClientRoutes.PF_REQUESTS).then(
+    (res) => res.data,
+  );
 };
 
 const approvePFRequest = (requestId: number): Promise<void> => {

--- a/src/components/DecisionConfirmation.tsx
+++ b/src/components/DecisionConfirmation.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import ConfirmationMessage from '../components/ConfirmationMessage';
+import { ContactInfo } from '../containers/setContacts/ducks/types';
+import { Button, Typography } from 'antd';
+import { Routes } from '../App';
+import styled from 'styled-components';
+import { ChungusContentContainer } from './index';
+
+const { Paragraph } = Typography;
+
+const StyledDiv = styled.div`
+  outline: 1px solid black;
+  width: 30%;
+  margin-left: 35%;
+`;
+
+const StyledParagraph = styled(Paragraph)`
+  text-align: center;
+`;
+
+const StyledButton = styled(Button)`
+  margin-top: 2%;
+  width: 6%;
+  margin-left: 47%;
+`;
+
+interface DecisionConfirmationProps {
+  readonly approved: boolean;
+  readonly contactInformation: ContactInfo;
+}
+
+const DecisionConfirmation: React.FC<DecisionConfirmationProps> = ({
+  approved,
+  contactInformation,
+}) => {
+  const message = `The ${
+    contactInformation.mainContact.lastName
+  } family has been ${approved ? 'approved!' : 'denied'}`;
+  const details = approved
+    ? 'An email to congratulate the new Participating Family is on its way. ' +
+      'Use the account owner’s details below for additional communications.'
+    : 'Is more information needed? Did you spot a mistake? ' +
+      'Use the account owner’s details below to reach out and clarify, or inquire.';
+
+  return (
+    <ChungusContentContainer>
+      <ConfirmationMessage
+        title="DECISION CONFIRMATION"
+        message={message}
+        details={details}
+      />
+      <StyledDiv>
+        <StyledParagraph>
+          <strong>First Name: </strong>
+          {contactInformation.mainContact.firstName}
+          <br />
+          <strong>Last Name: </strong>
+          {contactInformation.mainContact.lastName}
+          <br />
+          <strong>Email: </strong>
+          {contactInformation.mainContact.email}
+        </StyledParagraph>
+      </StyledDiv>
+      <StyledButton href={Routes.VIEW_REQUESTS} type="primary">
+        Done
+      </StyledButton>
+    </ChungusContentContainer>
+  );
+};
+
+export default DecisionConfirmation;

--- a/src/components/DecisionConfirmation.tsx
+++ b/src/components/DecisionConfirmation.tsx
@@ -5,17 +5,21 @@ import { Button, Typography } from 'antd';
 import { Routes } from '../App';
 import styled from 'styled-components';
 import { ChungusContentContainer } from './index';
+import { LIGHT_GREY } from '../utils/colors';
 
 const { Paragraph } = Typography;
 
 const StyledDiv = styled.div`
-  outline: 1px solid black;
+  outline: 1px solid ${LIGHT_GREY};
+  border-radius: 5px;
+  padding: 0.5rem;
   width: 30%;
   margin-left: 35%;
 `;
 
 const StyledParagraph = styled(Paragraph)`
   text-align: center;
+  margin-bottom: 0;
 `;
 
 const StyledButton = styled(Button)`

--- a/src/components/PFRequestsTable.tsx
+++ b/src/components/PFRequestsTable.tsx
@@ -3,13 +3,17 @@ import protectedApiClient, {
   PFRequestResponse,
 } from '../api/protectedApiClient';
 import { LinkButton } from './LinkButton';
-import { Table } from 'antd';
+import { Table, Typography} from 'antd';
 import styled from 'styled-components';
+const { Title } = Typography;
 
 const RequestsTable = styled(Table)`
-  display: flex;
-  justify-content: left;
-  align-items: center;
+  max-width: 60%;
+  margin-left: 16px;
+`;
+
+const StyledTitle = styled(Title)`
+  margin-top: 10px;
   margin-left: 16px;
 `;
 
@@ -22,27 +26,20 @@ interface PFRequestData {
 const columns = [
   {
     title: 'Account Owner',
-    width: 100,
     dataIndex: 'name',
-    key: 'name',
   },
   {
     title: 'Email',
-    width: 100,
     dataIndex: 'email',
-    key: 'email',
   },
   {
     title: 'Phone Number',
     dataIndex: 'phoneNumber',
-    key: '1',
-    width: 150,
   },
   {
     title: '',
     dataIndex: 'viewRequest',
-    key: '2',
-    width: 150,
+    width: '20px',
   },
 ];
 
@@ -59,7 +56,7 @@ const PFRequestsTable = () => {
             email: pfRequest.user.email,
             phoneNumber: pfRequest.user.phoneNumber,
             viewRequest: (
-              <LinkButton to={'/view-request/' + pfRequest.user.id}>
+              <LinkButton to={'/view-request/' + pfRequest.id}>
                 View Request
               </LinkButton>
             ),
@@ -70,7 +67,17 @@ const PFRequestsTable = () => {
     getPFRequestsData();
   }, []);
 
-  return <RequestsTable bordered dataSource={data} columns={columns} />;
+  return (
+    <>
+      <StyledTitle>Pending Requests</StyledTitle>
+      <RequestsTable
+        bordered
+        dataSource={data}
+        columns={columns}
+        pagination={{ pageSize: 5 }}
+      />
+    </>
+  );
 };
 
 export default PFRequestsTable;

--- a/src/components/PFRequestsTable.tsx
+++ b/src/components/PFRequestsTable.tsx
@@ -2,13 +2,12 @@ import React, { useEffect, useState } from 'react';
 import protectedApiClient, {
   PFRequestResponse,
 } from '../api/protectedApiClient';
-import { LinkButton } from './LinkButton';
+import { Link } from 'react-router-dom';
 import { Table, Typography } from 'antd';
 import styled from 'styled-components';
 const { Title } = Typography;
 
 const RequestsTable = styled(Table)`
-  max-width: 60%;
   margin-left: 16px;
 `;
 
@@ -37,9 +36,8 @@ const columns = [
     dataIndex: 'phoneNumber',
   },
   {
-    title: '',
+    title: 'Actions',
     dataIndex: 'viewRequest',
-    width: '20px',
   },
 ];
 
@@ -56,11 +54,7 @@ const PFRequestsTable = () => {
             email: pfRequest.user.email,
             phoneNumber: pfRequest.user.phoneNumber,
             viewRequest: (
-              <LinkButton
-                to={'/view-request/' + pfRequest.id + '/' + pfRequest.user.id}
-              >
-                View Request
-              </LinkButton>
+              <Link to={'/view-request/' + pfRequest.id}>View Request</Link>
             ),
           };
         }),

--- a/src/components/PFRequestsTable.tsx
+++ b/src/components/PFRequestsTable.tsx
@@ -48,7 +48,7 @@ const PFRequestsTable = () => {
     const getPFRequestsData = async () => {
       const pfRequests: PFRequestResponse = await protectedApiClient.getPFRequests();
       setData(
-        pfRequests.data.requests.map((pfRequest) => {
+        pfRequests.requests.map((pfRequest) => {
           return {
             name: pfRequest.user.firstName.concat(' ', pfRequest.user.lastName),
             email: pfRequest.user.email,

--- a/src/components/PFRequestsTable.tsx
+++ b/src/components/PFRequestsTable.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import protectedApiClient, {
+  PFRequestResponse,
+} from '../api/protectedApiClient';
+import { LinkButton } from './LinkButton';
+import { Table } from 'antd';
+import styled from 'styled-components';
+
+const RequestsTable = styled(Table)`
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  margin-left: 16px;
+`;
+
+interface PFRequestData {
+  name: string;
+  email: string;
+  phoneNumber: string;
+}
+
+const columns = [
+  {
+    title: 'Account Owner',
+    width: 100,
+    dataIndex: 'name',
+    key: 'name',
+  },
+  {
+    title: 'Email',
+    width: 100,
+    dataIndex: 'email',
+    key: 'email',
+  },
+  {
+    title: 'Phone Number',
+    dataIndex: 'phoneNumber',
+    key: '1',
+    width: 150,
+  },
+  {
+    title: '',
+    dataIndex: 'viewRequest',
+    key: '2',
+    width: 150,
+  },
+];
+
+const PFRequestsTable = () => {
+  const [data, setData] = useState<PFRequestData[]>([]);
+
+  useEffect(() => {
+    const getPFRequestsData = async () => {
+      const pfRequests: PFRequestResponse = await protectedApiClient.getPFRequests();
+      setData(
+        pfRequests.data.requests.map((pfRequest) => {
+          return {
+            name: pfRequest.user.firstName.concat(' ', pfRequest.user.lastName),
+            email: pfRequest.user.email,
+            phoneNumber: pfRequest.user.phoneNumber,
+            viewRequest: (
+              <LinkButton to={'/view-request/' + pfRequest.user.id}>
+                View Request
+              </LinkButton>
+            ),
+          };
+        }),
+      );
+    };
+    getPFRequestsData();
+  }, []);
+
+  return <RequestsTable bordered dataSource={data} columns={columns} />;
+};
+
+export default PFRequestsTable;

--- a/src/components/PFRequestsTable.tsx
+++ b/src/components/PFRequestsTable.tsx
@@ -3,7 +3,7 @@ import protectedApiClient, {
   PFRequestResponse,
 } from '../api/protectedApiClient';
 import { LinkButton } from './LinkButton';
-import { Table, Typography} from 'antd';
+import { Table, Typography } from 'antd';
 import styled from 'styled-components';
 const { Title } = Typography;
 
@@ -56,7 +56,9 @@ const PFRequestsTable = () => {
             email: pfRequest.user.email,
             phoneNumber: pfRequest.user.phoneNumber,
             viewRequest: (
-              <LinkButton to={'/view-request/' + pfRequest.id}>
+              <LinkButton
+                to={'/view-request/' + pfRequest.id + '/' + pfRequest.user.id}
+              >
                 View Request
               </LinkButton>
             ),

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -93,6 +93,10 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
     'My Events': Routes.MY_EVENTS,
   };
 
+  const adminLinks = {
+    'View Requests': Routes.VIEW_REQUESTS,
+  };
+
   // Dropdown menu options for the logged in
   const userMenu = (
     <Menu>
@@ -204,6 +208,34 @@ const NavBar: React.FC<NavBarProps> = ({ tokens }) => {
                 {privilegeLevel !== PrivilegeLevel.NONE && (
                   <>
                     {Object.entries(authLinks).map(([link, path], i) => (
+                      <Col key={i}>
+                        {path === location.pathname ? (
+                          <ActiveNavBarButton
+                            type="link"
+                            onClick={() => {
+                              history.push(path);
+                            }}
+                          >
+                            {link}
+                          </ActiveNavBarButton>
+                        ) : (
+                          <NavBarButton
+                            tab-index="0"
+                            type="link"
+                            onClick={() => {
+                              history.push(path);
+                            }}
+                          >
+                            {link}
+                          </NavBarButton>
+                        )}
+                      </Col>
+                    ))}{' '}
+                  </>
+                )}
+                {privilegeLevel === PrivilegeLevel.ADMIN && (
+                  <>
+                    {Object.entries(adminLinks).map(([link, path], i) => (
                       <Col key={i}>
                         {path === location.pathname ? (
                           <ActiveNavBarButton

--- a/src/containers/deactivateAccount/ducks/thunks.ts
+++ b/src/containers/deactivateAccount/ducks/thunks.ts
@@ -14,7 +14,9 @@ type UserAuthenticationAndDeactivateAccountThunkAction<R> = ThunkAction<
   UserAuthenticationActions | DeactivateAccountActions
 >;
 
-export const requestToDeactivateAccount = (): UserAuthenticationAndDeactivateAccountThunkAction<void> => {
+export const requestToDeactivateAccount = (): UserAuthenticationAndDeactivateAccountThunkAction<
+  void
+> => {
   return (dispatch, _getState, { protectedApiClient }) => {
     dispatch(deactivateAccount.loading());
     return protectedApiClient

--- a/src/containers/setContacts/ducks/types.ts
+++ b/src/containers/setContacts/ducks/types.ts
@@ -20,6 +20,7 @@ export type ContactsThunkAction<R> = ThunkAction<
 >;
 
 interface AbstractContact<D, P> {
+  id?: number;
   firstName: string;
   lastName: string;
   phoneNumber: string;
@@ -49,7 +50,7 @@ export interface ContactInfo {
   additionalContacts: AdditionalContact[];
   children: Child[];
   location: Location;
-  privilegeLevel: PrivilegeLevel;
+  privilegeLevel?: PrivilegeLevel;
 }
 
 export type Contact = GenericContact<Date, string>;

--- a/src/containers/setContacts/ducks/types.ts
+++ b/src/containers/setContacts/ducks/types.ts
@@ -5,6 +5,7 @@ import { C4CState } from '../../../store';
 import { AsyncRequest } from '../../../utils/asyncRequest';
 import { FileField } from '../../../utils/fileEncoding';
 import { ContactsActions } from './actions';
+import { PrivilegeLevel } from '../../../auth/ducks/types';
 
 export interface ContactsReducerState {
   readonly contacts: AsyncRequest<ContactInfo, any>;
@@ -48,6 +49,7 @@ export interface ContactInfo {
   additionalContacts: AdditionalContact[];
   children: Child[];
   location: Location;
+  privilegeLevel: PrivilegeLevel;
 }
 
 export type Contact = GenericContact<Date, string>;

--- a/src/containers/viewRequests/index.tsx
+++ b/src/containers/viewRequests/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import PFRequestsTable from '../../components/PFRequestsTable';
+import { ChungusContentContainer } from '../../components';
 
 const ViewRequests = () => {
   return (
@@ -12,7 +13,9 @@ const ViewRequests = () => {
           content="View all pending participating family requests and current registered families"
         />
       </Helmet>
-      <PFRequestsTable />
+      <ChungusContentContainer>
+        <PFRequestsTable />
+      </ChungusContentContainer>
     </>
   );
 };

--- a/src/containers/viewRequests/index.tsx
+++ b/src/containers/viewRequests/index.tsx
@@ -1,41 +1,20 @@
 import React from 'react';
-import { Button, Table } from 'antd';
-import styled from 'styled-components';
-
-const RequestsTable = styled(Table)`
-  max-width: 960px;
-  margin-left: 75px;
-`;
-
-const columns = [
-  {
-    title: 'Account Owner',
-    width: 100,
-    dataIndex: 'name',
-    key: 'name',
-  },
-  {
-    title: 'Email',
-    width: 100,
-    dataIndex: 'age',
-    key: 'age',
-  },
-  {
-    title: 'Phone Number',
-    dataIndex: 'address',
-    key: '1',
-    width: 150,
-  },
-  {
-    title: 'View Request',
-    dataIndex: 'address',
-    key: '2',
-    width: 150,
-  },
-];
+import { Helmet } from 'react-helmet';
+import PFRequestsTable from '../../components/PFRequestsTable';
 
 const ViewRequests = () => {
-  return <RequestsTable bordered dataSource={[]} columns={columns} />;
+  return (
+    <>
+      <Helmet>
+        <title>View Family Details</title>
+        <meta
+          name="description"
+          content="View all pending participating family requests and current registered families"
+        />
+      </Helmet>
+      <PFRequestsTable />
+    </>
+  );
 };
 
 export default ViewRequests;

--- a/src/containers/viewRequests/index.tsx
+++ b/src/containers/viewRequests/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Button, Table } from 'antd';
+import styled from 'styled-components';
+
+const RequestsTable = styled(Table)`
+  max-width: 960px;
+  margin-left: 75px;
+`;
+
+const columns = [
+  {
+    title: 'Account Owner',
+    width: 100,
+    dataIndex: 'name',
+    key: 'name',
+  },
+  {
+    title: 'Email',
+    width: 100,
+    dataIndex: 'age',
+    key: 'age',
+  },
+  {
+    title: 'Phone Number',
+    dataIndex: 'address',
+    key: '1',
+    width: 150,
+  },
+  {
+    title: 'View Request',
+    dataIndex: 'address',
+    key: '2',
+    width: 150,
+  },
+];
+
+const ViewRequests = () => {
+  return <RequestsTable bordered dataSource={[]} columns={columns} />;
+};
+
+export default ViewRequests;

--- a/src/containers/viewSingleRequest/index.tsx
+++ b/src/containers/viewSingleRequest/index.tsx
@@ -102,7 +102,7 @@ const ViewSingleRequest = () => {
           setContacts(AsyncRequestFailed(error));
         });
     }
-  }, [contacts, requestId]);
+  }, [contacts, requestId, history]);
 
   if (status === Status.APPROVED && asyncRequestIsComplete(contacts)) {
     return (

--- a/src/containers/viewSingleRequest/index.tsx
+++ b/src/containers/viewSingleRequest/index.tsx
@@ -1,0 +1,89 @@
+import { useParams } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import {
+  AsyncRequest,
+  AsyncRequestCompleted,
+  AsyncRequestFailed,
+  asyncRequestIsComplete,
+  asyncRequestIsFailed,
+  asyncRequestIsLoading,
+  asyncRequestIsNotStarted,
+  AsyncRequestLoading,
+  AsyncRequestNotStarted,
+} from '../../utils/asyncRequest';
+import { ContactInfo } from '../setContacts/ducks/types';
+import protectedApiClient from '../../api/protectedApiClient';
+import { Helmet } from 'react-helmet';
+import { ChungusContentContainer } from '../../components';
+import ContactInfoSummary from '../../components/ContactInfoSummary';
+import { Alert, Spin, Button, Table } from 'antd';
+import styled from 'styled-components';
+import { LinkButton } from '../../components/LinkButton';
+
+const DecisionButtons = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledButton = styled(Button)`
+  margin: 5px;
+`;
+
+const ViewSingleRequest = () => {
+  const id = Number(useParams<{ id: string }>().id);
+  const [contacts, setContacts] = useState<AsyncRequest<ContactInfo, any>>(
+    AsyncRequestNotStarted(),
+  );
+
+  useEffect(() => {
+    if (asyncRequestIsNotStarted(contacts)) {
+      setContacts(AsyncRequestLoading());
+      protectedApiClient
+        .getContactInfoById(id)
+        .then((c) => {
+          setContacts(AsyncRequestCompleted(c));
+        })
+        .catch((error) => {
+          setContacts(AsyncRequestFailed(error));
+        });
+    }
+  }, [contacts, id]);
+
+  return (
+    <>
+      <Helmet>
+        <title>View Family Details</title>
+        <meta
+          name="description"
+          content="Specific details about a registered family."
+        />
+      </Helmet>
+      <ChungusContentContainer>
+        <LinkButton type="link" to={'/view-requests/'}>
+          &lt; Back to Requests
+        </LinkButton>
+        {asyncRequestIsComplete(contacts) && (
+          <ContactInfoSummary userId={id} info={contacts.result} />
+        )}
+        {asyncRequestIsLoading(contacts) && <Spin />}
+        {asyncRequestIsFailed(contacts) && (
+          <Alert
+            message="Error"
+            description={contacts.error.message}
+            type="error"
+            showIcon
+          />
+        )}
+      </ChungusContentContainer>
+      <DecisionButtons>
+        <StyledButton type="primary" danger>
+          Deny
+        </StyledButton>
+        <StyledButton type="primary">Approve</StyledButton>
+      </DecisionButtons>
+    </>
+  );
+};
+
+export default ViewSingleRequest;

--- a/src/containers/viewSingleRequest/index.tsx
+++ b/src/containers/viewSingleRequest/index.tsx
@@ -12,13 +12,22 @@ import {
   AsyncRequestNotStarted,
 } from '../../utils/asyncRequest';
 import { ContactInfo } from '../setContacts/ducks/types';
-import protectedApiClient from '../../api/protectedApiClient';
 import { Helmet } from 'react-helmet';
-import { ChungusContentContainer } from '../../components';
+import { ChungusContentContainer, ContentContainer } from '../../components';
 import ContactInfoSummary from '../../components/ContactInfoSummary';
-import { Alert, Spin, Button, Table } from 'antd';
+import { Alert, Spin, Button, Table, Typography } from 'antd';
 import styled from 'styled-components';
 import { LinkButton } from '../../components/LinkButton';
+import protectedApiClient from '../../api/protectedApiClient';
+import { Routes } from '../../App';
+
+const { Title } = Typography;
+
+enum Status {
+  PENDING,
+  APPROVED,
+  DENIED,
+}
 
 const DecisionButtons = styled.div`
   display: flex;
@@ -30,17 +39,39 @@ const StyledButton = styled(Button)`
   margin: 5px;
 `;
 
+const StyledText = styled(Typography)`
+  align-items: center;
+`;
+
 const ViewSingleRequest = () => {
-  const id = Number(useParams<{ id: string }>().id);
+  const requestId = Number(
+    useParams<{ request_id: string; user_id: string }>().request_id,
+  );
+  const userId = Number(
+    useParams<{ request_id: string; user_id: string }>().user_id,
+  );
   const [contacts, setContacts] = useState<AsyncRequest<ContactInfo, any>>(
     AsyncRequestNotStarted(),
   );
+  const [status, setStatus] = useState<Status>(Status.PENDING);
+
+  const denyRequest = () => {
+    protectedApiClient
+      .denyPFRequest(requestId)
+      .then((res) => setStatus(Status.DENIED));
+  };
+
+  const approveRequest = () => {
+    protectedApiClient
+      .approvePFRequest(requestId)
+      .then((res) => setStatus(Status.APPROVED));
+  };
 
   useEffect(() => {
     if (asyncRequestIsNotStarted(contacts)) {
       setContacts(AsyncRequestLoading());
       protectedApiClient
-        .getContactInfoById(id)
+        .getContactInfoById(userId)
         .then((c) => {
           setContacts(AsyncRequestCompleted(c));
         })
@@ -48,42 +79,80 @@ const ViewSingleRequest = () => {
           setContacts(AsyncRequestFailed(error));
         });
     }
-  }, [contacts, id]);
+  }, [contacts, userId]);
 
-  return (
-    <>
-      <Helmet>
-        <title>View Family Details</title>
-        <meta
-          name="description"
-          content="Specific details about a registered family."
-        />
-      </Helmet>
-      <ChungusContentContainer>
-        <LinkButton type="link" to={'/view-requests/'}>
-          &lt; Back to Requests
-        </LinkButton>
-        {asyncRequestIsComplete(contacts) && (
-          <ContactInfoSummary userId={id} info={contacts.result} />
-        )}
-        {asyncRequestIsLoading(contacts) && <Spin />}
-        {asyncRequestIsFailed(contacts) && (
-          <Alert
-            message="Error"
-            description={contacts.error.message}
-            type="error"
-            showIcon
-          />
-        )}
-      </ChungusContentContainer>
-      <DecisionButtons>
-        <StyledButton type="primary" danger>
-          Deny
-        </StyledButton>
-        <StyledButton type="primary">Approve</StyledButton>
-      </DecisionButtons>
-    </>
-  );
+  switch (status) {
+    case Status.PENDING:
+      return (
+        <>
+          <Helmet>
+            <title>View Family Details</title>
+            <meta
+              name="description"
+              content="Specific details about a registered family."
+            />
+          </Helmet>
+          <ChungusContentContainer>
+            <LinkButton type="link" to={'/view-requests/'}>
+              &lt; Back to Requests
+            </LinkButton>
+            {asyncRequestIsComplete(contacts) && (
+              <ContactInfoSummary userId={userId} info={contacts.result} />
+            )}
+            {asyncRequestIsLoading(contacts) && <Spin />}
+            {asyncRequestIsFailed(contacts) && (
+              <Alert
+                message="Error"
+                description={contacts.error.message}
+                type="error"
+                showIcon
+              />
+            )}
+          </ChungusContentContainer>
+          <DecisionButtons>
+            <StyledButton
+              type="default"
+              danger
+              onClick={() => {
+                denyRequest();
+              }}
+            >
+              Deny
+            </StyledButton>
+            <StyledButton
+              type="primary"
+              onClick={() => {
+                approveRequest();
+              }}
+            >
+              Approve
+            </StyledButton>
+          </DecisionButtons>
+        </>
+      );
+    case Status.APPROVED:
+      return (
+        <ContentContainer>
+          <Title>The {contacts.result.mainContact.lastName} Family has been approved</Title>
+          <StyledText>
+            An email to congratulate the new Participating Family is on its way.
+            Use the account owner’s details below for additional communications.
+          </StyledText>
+          <Button to={Routes.HOME}>Done</Button>
+        </ContentContainer>
+      );
+    case Status.DENIED:
+      return (
+        <ContentContainer>
+          <Title>The {user.lastName} Family has been denied</Title>
+          <StyledText>
+            Is more information needed? Did you spot a mistake? Use the account
+            owner’s details below to reach out and clarify, or inquire.
+          </StyledText>
+          <Button to={Routes.HOME}>Done</Button>
+        </ContentContainer>
+      );
+  }
 };
 
 export default ViewSingleRequest;

--- a/src/containers/viewSingleRequest/index.tsx
+++ b/src/containers/viewSingleRequest/index.tsx
@@ -13,13 +13,15 @@ import {
 } from '../../utils/asyncRequest';
 import { ContactInfo } from '../setContacts/ducks/types';
 import { Helmet } from 'react-helmet';
-import { ChungusContentContainer, ContentContainer } from '../../components';
+import { ChungusContentContainer } from '../../components';
 import ContactInfoSummary from '../../components/ContactInfoSummary';
-import { Alert, Spin, Button } from 'antd';
+import { Alert, Button, Spin } from 'antd';
 import styled from 'styled-components';
 import { LinkButton } from '../../components/LinkButton';
 import protectedApiClient from '../../api/protectedApiClient';
 import DecisionConfirmation from '../../components/DecisionConfirmation';
+import { PrivilegeLevel } from '../../auth/ducks/types';
+import { useHistory } from 'react-router';
 
 enum Status {
   PENDING,
@@ -43,6 +45,7 @@ const StyledAlert = styled(Alert)`
 `;
 
 const ViewSingleRequest = () => {
+  const history = useHistory();
   const requestId = Number(
     useParams<{ request_id: string; user_id: string }>().request_id,
   );
@@ -90,6 +93,11 @@ const ViewSingleRequest = () => {
         .getContactInfoById(userId)
         .then((c) => {
           setContacts(AsyncRequestCompleted(c));
+          // redirect to NotFound component if this request has already been dealt with
+          if (c.privilegeLevel.toLowerCase() !== PrivilegeLevel.STANDARD) {
+            // TODO: idk how react-router works, is there a better way to do this?
+            history.push('/not-found');
+          }
         })
         .catch((error) => {
           setContacts(AsyncRequestFailed(error));


### PR DESCRIPTION
## Issue

Closes #[95](https://github.com/Code-4-Community/lucys-love-bus-frontend/issues/95)

## Changes

- [X ] Page to view all PF requests
- [X ] Ability to inspect each individual request and see detailed information (see Family Details issue)
- [X ] Ability to accept or reject
- [X ] Routed to a confirmation page

## Screenshots
![image](https://user-images.githubusercontent.com/55663529/115490452-fea0e380-a212-11eb-8d18-8ec668deef10.png)
![image](https://user-images.githubusercontent.com/55663529/115490516-1b3d1b80-a213-11eb-92e1-11a341ed2943.png)
![image](https://user-images.githubusercontent.com/55663529/115490324-b84b8480-a212-11eb-86ac-0babee2905ec.png)


## Verification Steps
- Verified status update of pf request table in the backend
- Made sure all pending requests were being displayed by the table

## Important
It's possible to go back to a user's request page (by typing in the appropriate URL parameters) and approve/deny the request AGAIN which overwrites the status in the backend. Should we be worried that an admin will be able to change a PF decision confirmation? This is a draft PR, after all. Thoughts? Comments? Recommendations?
