### PR TITLE
Update Event Registration + Ticket Details for Single Event

### DIFF
--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -2,12 +2,12 @@ import AppAxiosInstance from '../auth/axios';
 import { AnnouncementFormData } from '../components/AnnouncementForm';
 import { UserSummary } from '../components/UserInfoTable';
 import { ChangeEmailRequest } from '../containers/changeAccountEmail/ducks/types';
+import { NewEventInformation } from '../containers/createEvent/ducks/types';
 import { Registration } from '../containers/eventRSVP/ducks/types';
 import { PersonalRequest } from '../containers/personalRequests/ducks/types';
 import { ContactInfo } from '../containers/setContacts/ducks/types';
 import { EventAnnouncement } from '../containers/singleEvent/ducks/types';
 import { EventInformation } from '../containers/upcoming-events/ducks/types';
-import { NewEventInformation } from '../containers/createEvent/ducks/types';
 
 export interface User {
   id: string;

--- a/src/api/protectedApiClient.ts
+++ b/src/api/protectedApiClient.ts
@@ -16,6 +16,9 @@ interface LineItem {
 interface RegisterTicketsRequest {
   lineItemRequests: LineItem[];
 }
+interface UpdateTicketsRequest {
+  quantity: number;
+}
 
 export interface ProtectedApiExtraArgs {
   readonly protectedApiClient: ProtectedApiClient;
@@ -27,6 +30,10 @@ export interface ProtectedApiClient {
     newPassword: string;
   }) => Promise<void>;
   readonly registerTickets: (request: RegisterTicketsRequest) => Promise<void>;
+  readonly updateTickets: (
+    eventId: number,
+    request: UpdateTicketsRequest,
+  ) => Promise<void>;
   readonly getMyEvents: () => Promise<EventInformation[]>;
   readonly getRequestStatuses: () => Promise<PersonalRequest[]>;
   readonly makePFRequest: () => Promise<void>;
@@ -76,6 +83,15 @@ const changePassword = (request: {
 const registerTickets = (request: RegisterTicketsRequest) => {
   return AppAxiosInstance.post(
     ProtectedApiClientRoutes.REGISTER_TICKETS,
+    request,
+  ).then((res) => {
+    return;
+  });
+};
+
+const updateTickets = (eventId: number, request: UpdateTicketsRequest) => {
+  return AppAxiosInstance.put(
+    `${ProtectedApiClientRoutes.REGISTER_TICKETS}/${eventId}`,
     request,
   ).then((res) => {
     return;
@@ -170,6 +186,7 @@ const deleteAnnouncement = (id: number): Promise<void> => {
 const Client: ProtectedApiClient = Object.freeze({
   changePassword,
   registerTickets,
+  updateTickets,
   getMyEvents,
   getRequestStatuses,
   makePFRequest,

--- a/src/components/AdminMenu.tsx
+++ b/src/components/AdminMenu.tsx
@@ -1,0 +1,94 @@
+import { Menu } from 'antd';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
+import styled from 'styled-components';
+import { Routes } from '../App';
+import { logout } from '../auth/ducks/thunks';
+import { UserAuthenticationReducerState } from '../auth/ducks/types';
+import { asyncRequestIsComplete } from '../utils/asyncRequest';
+
+const StyledMenu = styled(Menu)`
+  min-width: 100px;
+`;
+// Dropdown menu options for the logged in
+const AdminMenu: React.FC<{
+  tokens: UserAuthenticationReducerState['tokens'];
+}> = ({ tokens }) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  return (
+    <StyledMenu>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.HOME);
+        }}
+      >
+        Home
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.UPCOMING_EVENTS);
+        }}
+      >
+        Upcoming Events
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.ANNOUNCEMENTS);
+        }}
+      >
+        Announcements
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.MY_EVENTS);
+        }}
+      >
+        My Events
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.CREATE_EVENT);
+        }}
+      >
+        Create Event
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.CREATE_ANNOUNCEMENTS);
+        }}
+      >
+        Make Announcement
+      </Menu.Item>
+
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.VIEW_REQUESTS);
+        }}
+      >
+        View Requests
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.SETTINGS);
+        }}
+      >
+        Settings
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          if (asyncRequestIsComplete(tokens)) {
+            dispatch(logout());
+            history.push(Routes.HOME);
+            history.go(0);
+          }
+        }}
+      >
+        Log Out
+      </Menu.Item>
+    </StyledMenu>
+  );
+};
+
+export default AdminMenu;

--- a/src/components/BugReportFooter.tsx
+++ b/src/components/BugReportFooter.tsx
@@ -2,7 +2,7 @@ import { BugOutlined } from '@ant-design/icons';
 import { Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
-import { PRIMARY } from '../utils/colors';
+import { LIGHT_GREY, PRIMARY } from '../utils/colors';
 const { Text, Link } = Typography;
 const LittleBugIcon = styled(BugOutlined)`
   margin: 3px;
@@ -18,8 +18,9 @@ const StickyFooter = styled.footer`
   display: flex;
   justify-content: center;
   background-color: rgba(255, 255, 255, 0.95);
-  border-top: 1px lightgray solid;
+  border-top: 1px ${LIGHT_GREY} solid;
   padding-top: 5px;
+  border-radius: 5px;
 `;
 
 const BugReportFooter: React.FC = () => {

--- a/src/components/NavDropdown.tsx
+++ b/src/components/NavDropdown.tsx
@@ -1,0 +1,100 @@
+import { DownOutlined, UserOutlined } from '@ant-design/icons';
+import { Avatar, Button, Col, Dropdown, Row, Typography } from 'antd';
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+import { Routes } from '../App';
+import {
+  PrivilegeLevel,
+  UserAuthenticationReducerState,
+} from '../auth/ducks/types';
+import { ContactsReducerState } from '../containers/setContacts/ducks/types';
+import { asyncRequestIsComplete } from '../utils/asyncRequest';
+import AdminMenu from './AdminMenu';
+import UserMenu from './UserMenu';
+
+const { Text } = Typography;
+
+const UserContainer = styled.div`
+  margin-right: 16px;
+`;
+
+const UserDropdown = styled(Dropdown)`
+  min-height: 50px;
+`;
+const UserAvatar = styled(Avatar)`
+  margin-right: 10px;
+`;
+
+const NavDropdown: React.FC<{
+  tokens: UserAuthenticationReducerState['tokens'];
+  contacts: ContactsReducerState['contacts'];
+
+  setDisplayLoginModal: React.Dispatch<React.SetStateAction<boolean>>;
+  privilegeLevel: PrivilegeLevel;
+}> = ({ tokens, contacts, privilegeLevel, setDisplayLoginModal }) => {
+  const history = useHistory();
+
+  return (
+    <UserContainer>
+      <Row gutter={[8, 0]}>
+        {privilegeLevel !== PrivilegeLevel.NONE ? (
+          <Col>
+            <UserDropdown
+              overlay={
+                privilegeLevel === PrivilegeLevel.ADMIN ? (
+                  <AdminMenu tokens={tokens} />
+                ) : (
+                  <UserMenu tokens={tokens} />
+                )
+              }
+            >
+              <Button>
+                <UserAvatar
+                  src={
+                    asyncRequestIsComplete(contacts)
+                      ? contacts.result.mainContact.profilePicture
+                      : undefined
+                  }
+                  icon={<UserOutlined />}
+                />
+                <Text>
+                  {asyncRequestIsComplete(contacts)
+                    ? `${contacts.result.mainContact.firstName} ${contacts.result.mainContact.lastName}`
+                    : 'Loading...'}
+                </Text>
+                <DownOutlined />
+              </Button>
+            </UserDropdown>
+          </Col>
+        ) : (
+          <>
+            <Col>
+              <Button
+                tab-index="0"
+                onClick={() => {
+                  setDisplayLoginModal(true);
+                }}
+              >
+                Login
+              </Button>
+            </Col>
+            <Col>
+              <Button
+                tab-index="0"
+                type="primary"
+                onClick={() => {
+                  history.push(Routes.SIGNUP);
+                }}
+              >
+                Sign Up
+              </Button>
+            </Col>
+          </>
+        )}
+      </Row>
+    </UserContainer>
+  );
+};
+
+export default NavDropdown;

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -59,6 +59,7 @@ const NavLinks: React.FC<{ privilegeLevel: PrivilegeLevel }> = ({
   };
   const userLinks = {
     'My Events': Routes.MY_EVENTS,
+    'My Requests': Routes.PERSONAL_REQUESTS,
   };
   const adminLinks = {
     'Create Event': Routes.CREATE_EVENT,
@@ -123,35 +124,35 @@ const NavLinks: React.FC<{ privilegeLevel: PrivilegeLevel }> = ({
                 )}
               </Col>
             ))}
-            {privilegeLevel === PrivilegeLevel.STANDARD ||
-              (privilegeLevel === PrivilegeLevel.PF && (
-                <>
-                  {Object.entries(userLinks).map(([link, path], i) => (
-                    <Col key={i}>
-                      {path === location.pathname ? (
-                        <ActiveNavBarButton
-                          type="link"
-                          onClick={() => {
-                            history.push(path);
-                          }}
-                        >
-                          {link}
-                        </ActiveNavBarButton>
-                      ) : (
-                        <NavBarButton
-                          tab-index="0"
-                          type="link"
-                          onClick={() => {
-                            history.push(path);
-                          }}
-                        >
-                          {link}
-                        </NavBarButton>
-                      )}
-                    </Col>
-                  ))}{' '}
-                </>
-              ))}
+            {(privilegeLevel === PrivilegeLevel.STANDARD ||
+              privilegeLevel === PrivilegeLevel.PF) && (
+              <>
+                {Object.entries(userLinks).map(([link, path], i) => (
+                  <Col key={i}>
+                    {path === location.pathname ? (
+                      <ActiveNavBarButton
+                        type="link"
+                        onClick={() => {
+                          history.push(path);
+                        }}
+                      >
+                        {link}
+                      </ActiveNavBarButton>
+                    ) : (
+                      <NavBarButton
+                        tab-index="0"
+                        type="link"
+                        onClick={() => {
+                          history.push(path);
+                        }}
+                      >
+                        {link}
+                      </NavBarButton>
+                    )}
+                  </Col>
+                ))}{' '}
+              </>
+            )}
             {privilegeLevel === PrivilegeLevel.ADMIN && (
               <>
                 {Object.entries(adminLinks).map(([link, path], i) => (

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -1,0 +1,190 @@
+import { Button, Col, Image, Row, Typography } from 'antd';
+import React from 'react';
+import { Link, useHistory, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import { Routes } from '../App';
+import { PrivilegeLevel } from '../auth/ducks/types';
+import { ORANGE } from '../utils/colors';
+
+const { Text } = Typography;
+
+const LogoContainer = styled.div`
+  padding-right: 24px;
+`;
+
+const TextColumn = styled(Col)`
+  padding-right: 16px;
+`;
+const NavBarText = styled(Text)`
+  font-size: 1.6em;
+  font-weight: 700;
+  line-height: 1.15;
+`;
+
+const Subtitle = styled(Text)`
+  color: ${ORANGE};
+`;
+
+const NavBarButton = styled(Button)`
+  color: black;
+  padding-left: 1em;
+  padding-right: 1em;
+  :active {
+    color: inherit;
+  }
+  :hover {
+    color: ${ORANGE};
+  }
+`;
+
+const ActiveNavBarButton = styled(NavBarButton)`
+  color: ${ORANGE};
+  font-weight: 500;
+`;
+
+const Logo = styled(Image)`
+  width: 100px;
+  margin: 16px;
+`;
+
+const NavLinks: React.FC<{ privilegeLevel: PrivilegeLevel }> = ({
+  privilegeLevel,
+}) => {
+  const location = useLocation();
+  const history = useHistory();
+  const links = {
+    Home: Routes.HOME,
+    'Upcoming Events': Routes.UPCOMING_EVENTS,
+    Announcements: Routes.ANNOUNCEMENTS,
+  };
+  const userLinks = {
+    'My Events': Routes.MY_EVENTS,
+  };
+  const adminLinks = {
+    'Create Event': Routes.CREATE_EVENT,
+    'Make Announcement': Routes.CREATE_ANNOUNCEMENTS,
+    'View Requests': Routes.VIEW_REQUESTS,
+  };
+  return (
+    <LogoContainer>
+      <Row justify="center" align="middle">
+        <Col>
+          <Link
+            to="/"
+            onClick={() => {
+              history.push('/');
+            }}
+          >
+            <Logo
+              src="https://lucys-love-bus-public.s3.us-east-2.amazonaws.com/LLB_logo_no_text.png"
+              alt="LLB Logo"
+              preview={false}
+            />
+          </Link>
+        </Col>
+        <TextColumn>
+          <Link
+            to="/"
+            onClick={() => {
+              history.push('/');
+            }}
+          >
+            <Row>
+              <NavBarText>Lucy's Love Bus</NavBarText>
+            </Row>
+            <Row>
+              <Subtitle>Event Registration</Subtitle>
+            </Row>
+          </Link>
+        </TextColumn>
+        <Col>
+          <Row justify="space-between">
+            {Object.entries(links).map(([link, path], i) => (
+              <Col key={i}>
+                {path === location.pathname ? (
+                  <ActiveNavBarButton
+                    type="link"
+                    onClick={() => {
+                      history.push(path);
+                    }}
+                  >
+                    {link}
+                  </ActiveNavBarButton>
+                ) : (
+                  <NavBarButton
+                    tab-index="0"
+                    type="link"
+                    onClick={() => {
+                      history.push(path);
+                    }}
+                  >
+                    {link}
+                  </NavBarButton>
+                )}
+              </Col>
+            ))}
+            {privilegeLevel === PrivilegeLevel.STANDARD ||
+              (privilegeLevel === PrivilegeLevel.PF && (
+                <>
+                  {Object.entries(userLinks).map(([link, path], i) => (
+                    <Col key={i}>
+                      {path === location.pathname ? (
+                        <ActiveNavBarButton
+                          type="link"
+                          onClick={() => {
+                            history.push(path);
+                          }}
+                        >
+                          {link}
+                        </ActiveNavBarButton>
+                      ) : (
+                        <NavBarButton
+                          tab-index="0"
+                          type="link"
+                          onClick={() => {
+                            history.push(path);
+                          }}
+                        >
+                          {link}
+                        </NavBarButton>
+                      )}
+                    </Col>
+                  ))}{' '}
+                </>
+              ))}
+            {privilegeLevel === PrivilegeLevel.ADMIN && (
+              <>
+                {Object.entries(adminLinks).map(([link, path], i) => (
+                  <Col key={i}>
+                    {path === location.pathname ? (
+                      <ActiveNavBarButton
+                        type="link"
+                        onClick={() => {
+                          history.push(path);
+                        }}
+                      >
+                        {link}
+                      </ActiveNavBarButton>
+                    ) : (
+                      <NavBarButton
+                        tab-index="0"
+                        type="link"
+                        onClick={() => {
+                          history.push(path);
+                        }}
+                      >
+                        {link}
+                      </NavBarButton>
+                    )}
+                  </Col>
+                ))}
+              </>
+            )}
+          </Row>
+        </Col>
+      </Row>
+    </LogoContainer>
+  );
+};
+
+export default NavLinks;

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -47,6 +47,13 @@ const UserMenu: React.FC<{
       >
         My Events
       </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.PERSONAL_REQUESTS);
+        }}
+      >
+        My Requests
+      </Menu.Item>
 
       <Menu.Item
         onClick={() => {

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,73 @@
+import { Menu } from 'antd';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
+import styled from 'styled-components';
+import { Routes } from '../App';
+import { logout } from '../auth/ducks/thunks';
+import { UserAuthenticationReducerState } from '../auth/ducks/types';
+import { asyncRequestIsComplete } from '../utils/asyncRequest';
+
+const StyledMenu = styled(Menu)`
+  min-width: 100px;
+`;
+// Dropdown menu options for the logged in
+const UserMenu: React.FC<{
+  tokens: UserAuthenticationReducerState['tokens'];
+}> = ({ tokens }) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  return (
+    <StyledMenu>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.HOME);
+        }}
+      >
+        Home
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.UPCOMING_EVENTS);
+        }}
+      >
+        Upcoming Events
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.ANNOUNCEMENTS);
+        }}
+      >
+        Announcements
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.MY_EVENTS);
+        }}
+      >
+        My Events
+      </Menu.Item>
+
+      <Menu.Item
+        onClick={() => {
+          history.push(Routes.SETTINGS);
+        }}
+      >
+        Settings
+      </Menu.Item>
+      <Menu.Item
+        onClick={() => {
+          if (asyncRequestIsComplete(tokens)) {
+            dispatch(logout());
+            history.push(Routes.HOME);
+            history.go(0);
+          }
+        }}
+      >
+        Log Out
+      </Menu.Item>
+    </StyledMenu>
+  );
+};
+
+export default UserMenu;

--- a/src/components/announcementsList/index.tsx
+++ b/src/components/announcementsList/index.tsx
@@ -9,6 +9,10 @@ import {
 } from '../../utils/copy';
 import { AnnouncementCard } from '../AnnouncementCard';
 
+const NoAnnouncementsContainer = styled.div`
+  min-height: 300px;
+`;
+
 const NoAnnouncementsSubText = styled.span`
   display: block;
   text-align: center;
@@ -31,6 +35,7 @@ const PageNumbersWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
+  margin-bottom: 3em;
 `;
 
 const PageNumber = styled.li`
@@ -54,12 +59,12 @@ const ArrowButton = styled(PageNumber)`
 `;
 
 const noAnnouncementsTexts: JSX.Element = (
-  <>
+  <NoAnnouncementsContainer>
     <NoAnnouncementsText>{NO_ANNOUNCEMENTS_HEADER}</NoAnnouncementsText>
     <NoAnnouncementsSubText>
       {NO_ANNOUNCEMENTS_SUBHEADER}
     </NoAnnouncementsSubText>
-  </>
+  </NoAnnouncementsContainer>
 );
 
 export interface AnnouncementsListProps {

--- a/src/components/event-details/EventDetails.tsx
+++ b/src/components/event-details/EventDetails.tsx
@@ -37,6 +37,10 @@ const Time = styled.div`
   margin-bottom: 0.5em;
 `;
 
+const SeatsRemaining = styled.div`
+  margin-bottom: 0.5em;
+`;
+
 const Location = styled.div`
   margin-bottom: 120px;
 `;
@@ -81,6 +85,8 @@ const EventDetails: React.FC<EventDetailsProps> = ({
   announcements,
   hasRegistered,
   ticketCount,
+  spotsAvailable,
+  capacity,
 }) => {
   const [
     displayEventRegistrationModal,
@@ -128,6 +134,9 @@ const EventDetails: React.FC<EventDetailsProps> = ({
                 </EventsTag>
               )}
               {computeDateString()}
+              <SeatsRemaining>
+                Seats Remaining: {spotsAvailable}/{capacity}
+              </SeatsRemaining>
               <Location>Location: {location}</Location>
               <GreenButton
                 onClick={() => {

--- a/src/components/event-details/EventDetails.tsx
+++ b/src/components/event-details/EventDetails.tsx
@@ -1,4 +1,4 @@
-import { Button, Col, Row, Typography } from 'antd';
+import { Button, Col, Row, Tag, Typography } from 'antd';
 import dateFormat from 'dateformat';
 import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
@@ -29,6 +29,7 @@ const CardContent = styled.div`
 `;
 
 const StyledTitle = styled(Title)`
+  display: inline;
   margin-top: 15px;
 `;
 
@@ -52,6 +53,10 @@ const Thumbnail = styled.img`
   object-fit: cover;
 `;
 
+const EventsTag = styled(Tag)`
+  margin: 1em;
+`;
+
 const Info = styled.div`
   margin-left: 40px;
   max-height: 350px;
@@ -64,6 +69,7 @@ const AnnouncementNoContent = styled(AnnouncementBox)``;
 export interface EventDetailsProps extends EventInformation {
   announcements?: EventAnnouncement[];
   privilegeLevel: PrivilegeLevel;
+  hasRegistered: boolean;
 }
 
 const EventDetails: React.FC<EventDetailsProps> = ({
@@ -73,6 +79,8 @@ const EventDetails: React.FC<EventDetailsProps> = ({
   details,
   privilegeLevel,
   announcements,
+  hasRegistered,
+  ticketCount,
 }) => {
   const [
     displayEventRegistrationModal,
@@ -107,17 +115,21 @@ const EventDetails: React.FC<EventDetailsProps> = ({
           </Col>
           <Col span={10}>
             <Info>
-              <StyledTitle level={3}>{title}</StyledTitle>
+              <StyledTitle level={3}>{title}</StyledTitle>{' '}
+              {ticketCount && (
+                <EventsTag color={'green'}>
+                  Registered {ticketCount} tickets
+                </EventsTag>
+              )}
               <Time>{computeDateString(start)}</Time>
               <Time>{computeTimeString(start, end)}</Time>
-
               <Location>Location: {location}</Location>
               <GreenButton
                 onClick={() => {
                   setDisplayEventRegistrationModal(true);
                 }}
               >
-                Register
+                {hasRegistered ? 'Update Registration' : 'Register'}
               </GreenButton>
             </Info>
           </Col>
@@ -160,6 +172,8 @@ const EventDetails: React.FC<EventDetailsProps> = ({
         onCloseEventRegistrationModal={() => {
           setDisplayEventRegistrationModal(false);
         }}
+        hasRegistered={hasRegistered}
+        ticketCount={ticketCount}
       />
     </>
   );

--- a/src/components/modals/event-registration-modal/EventRegistrationModal.tsx
+++ b/src/components/modals/event-registration-modal/EventRegistrationModal.tsx
@@ -1,8 +1,10 @@
 import { Alert, InputNumber, Modal, Typography } from 'antd';
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import protectedApiClient from '../../../api/protectedApiClient';
 import { PrivilegeLevel } from '../../../auth/ducks/types';
+import { getMyEvents } from '../../../containers/myEvents/ducks/thunks';
 import {
   AsyncRequest,
   AsyncRequestCompleted,
@@ -67,6 +69,7 @@ const EventRegistrationModal: React.FC<EventRegistrationModalProps> = ({
   hasRegistered,
   ticketCount,
 }) => {
+  const dispatch = useDispatch();
   const [quantity, setQuantity] = React.useState<number>(ticketCount || 1);
   const [registrationRequest, setRegistrationRequest] = React.useState<
     AsyncRequest<void, any>
@@ -100,6 +103,7 @@ const EventRegistrationModal: React.FC<EventRegistrationModalProps> = ({
 
       onCloseEventRegistrationModal();
       setRegistrationRequest(AsyncRequestCompleted(undefined));
+      dispatch(getMyEvents());
     } catch (e) {
       setRegistrationRequest(AsyncRequestFailed(e));
     }

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -1,62 +1,19 @@
-import { DownOutlined, UserOutlined } from '@ant-design/icons';
-import {
-  Avatar,
-  Badge,
-  Button,
-  Col,
-  Dropdown,
-  Image,
-  Menu,
-  Row,
-  Typography,
-} from 'antd';
 import React, { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import { Link, useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { Routes } from '../../App';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
-import { logout } from '../../auth/ducks/thunks';
 import {
   PrivilegeLevel,
   UserAuthenticationReducerState,
 } from '../../auth/ducks/types';
 import { getRequestStatuses } from '../../containers/personalRequests/ducks/thunks';
-import {
-  PersonalRequest,
-  PersonalRequestsReducerState,
-} from '../../containers/personalRequests/ducks/types';
 import { getContactInfo } from '../../containers/setContacts/ducks/thunks';
 import { ContactsReducerState } from '../../containers/setContacts/ducks/types';
 import { C4CState } from '../../store';
 import { asyncRequestIsComplete } from '../../utils/asyncRequest';
-import { ORANGE } from '../../utils/colors';
 import LoginModal from '../modals/login-modal/LoginModal';
-
-const { Text } = Typography;
-
-// Custom styling for the navbar links - Home, Upcoming Events, My Events
-const NavBarButton = styled(Button)`
-  color: black;
-  padding-left: 1em;
-  padding-right: 1em;
-  :active {
-    color: inherit;
-  }
-  :hover {
-    color: ${ORANGE};
-  }
-`;
-
-const ActiveNavBarButton = styled(NavBarButton)`
-  color: ${ORANGE};
-  font-weight: 500;
-`;
-
-const Logo = styled(Image)`
-  width: 100px;
-  margin: 16px;
-`;
+import NavDropdown from '../NavDropdown';
+import NavLinks from '../NavLinks';
 
 const NavBarContainer = styled.div`
   margin: auto;
@@ -69,436 +26,35 @@ const NavBarContainer = styled.div`
   max-width: 1440px;
 `;
 
-const LogoContainer = styled.div`
-  padding-right: 24px;
-`;
-
-const TextColumn = styled(Col)`
-  padding-right: 16px;
-`;
-const NavBarText = styled(Text)`
-  font-size: 1.6em;
-  font-weight: 700;
-  line-height: 1.15;
-`;
-
-const Subtitle = styled(Text)`
-  color: ${ORANGE};
-`;
-
-const UserContainer = styled.div`
-  margin-right: 16px;
-`;
-
-const UserMenu = styled(Menu)`
-  min-width: 100px;
-`;
-const UserDropdown = styled(Dropdown)`
-  min-height: 50px;
-`;
-const UserAvatar = styled(Avatar)`
-  margin-right: 10px;
-`;
-
 interface NavBarProps {
   readonly tokens: UserAuthenticationReducerState['tokens'];
   readonly contacts: ContactsReducerState['contacts'];
-  readonly personalRequests: PersonalRequestsReducerState['personalRequests'];
 }
 
-const NavBar: React.FC<NavBarProps> = ({
-  tokens,
-  contacts,
-  personalRequests,
-}) => {
-  const history = useHistory();
-  const location = useLocation();
+const NavBar: React.FC<NavBarProps> = ({ tokens, contacts }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
     if (asyncRequestIsComplete(tokens)) {
       dispatch(getContactInfo());
-    }
-  }, [dispatch, tokens]);
-
-  const privilegeLevel: PrivilegeLevel = getPrivilegeLevel(tokens);
-  const links = {
-    Home: Routes.HOME,
-    'Upcoming Events': Routes.UPCOMING_EVENTS,
-    Announcements: Routes.ANNOUNCEMENTS,
-  };
-  const authLinks = {
-    'My Events': Routes.MY_EVENTS,
-  };
-  const adminLinks = {
-    'Create Event': Routes.CREATE_EVENT,
-    'Make Announcement': Routes.CREATE_ANNOUNCEMENTS,
-  };
-
-  useEffect(() => {
-    if (asyncRequestIsComplete(tokens)) {
       dispatch(getRequestStatuses());
     }
   }, [dispatch, tokens]);
 
-  // Dropdown menu options for the logged in
-  const userMenu = (
-    <UserMenu>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.HOME);
-        }}
-      >
-        Home
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.UPCOMING_EVENTS);
-        }}
-      >
-        Upcoming Events
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.ANNOUNCEMENTS);
-        }}
-      >
-        Announcements
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.MY_EVENTS);
-        }}
-      >
-        My Events
-      </Menu.Item>
-
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.SETTINGS);
-        }}
-      >
-        Settings
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          if (asyncRequestIsComplete(tokens)) {
-            dispatch(logout());
-            history.push(Routes.HOME);
-            history.go(0);
-          }
-        }}
-      >
-        Log Out
-      </Menu.Item>
-    </UserMenu>
-  );
-
-  // Dropdown menu options for the logged in
-  const adminMenu = (
-    <UserMenu>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.HOME);
-        }}
-      >
-        Home
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.UPCOMING_EVENTS);
-        }}
-      >
-        Upcoming Events
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.ANNOUNCEMENTS);
-        }}
-      >
-        Announcements
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.MY_EVENTS);
-        }}
-      >
-        My Events
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.CREATE_EVENT);
-        }}
-      >
-        Create Event
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.CREATE_ANNOUNCEMENTS);
-        }}
-      >
-        Make Announcement
-      </Menu.Item>
-
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.VIEW_REQUESTS);
-        }}
-      >
-        View Requests
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          history.push(Routes.SETTINGS);
-        }}
-      >
-        Settings
-      </Menu.Item>
-      <Menu.Item
-        onClick={() => {
-          if (asyncRequestIsComplete(tokens)) {
-            dispatch(logout());
-            history.push(Routes.HOME);
-            history.go(0);
-          }
-        }}
-      >
-        Log Out
-      </Menu.Item>
-    </UserMenu>
-  );
+  const privilegeLevel: PrivilegeLevel = getPrivilegeLevel(tokens);
 
   const [displayLoginModal, setDisplayLoginModal] = useState(false);
-
-  const getNumPendingRequests = (requests: PersonalRequest[]) => {
-    return requests.filter((request) => request.status === 'PENDING').length;
-  };
 
   return (
     <>
       <NavBarContainer>
-        <LogoContainer>
-          <Row justify="center" align="middle">
-            <Col>
-              <Link
-                to="/"
-                onClick={() => {
-                  history.push('/');
-                }}
-              >
-                <Logo
-                  src="https://lucys-love-bus-public.s3.us-east-2.amazonaws.com/LLB_logo_no_text.png"
-                  alt="LLB Logo"
-                  preview={false}
-                />
-              </Link>
-            </Col>
-            <TextColumn>
-              <Link
-                to="/"
-                onClick={() => {
-                  history.push('/');
-                }}
-              >
-                <Row>
-                  <NavBarText>Lucy's Love Bus</NavBarText>
-                </Row>
-                <Row>
-                  <Subtitle>Event Registration</Subtitle>
-                </Row>
-              </Link>
-            </TextColumn>
-            <Col>
-              <Row justify="space-between">
-                {Object.entries(links).map(([link, path], i) => (
-                  <Col key={i}>
-                    {path === location.pathname ? (
-                      <ActiveNavBarButton
-                        type="link"
-                        onClick={() => {
-                          history.push(path);
-                        }}
-                      >
-                        {link}
-                      </ActiveNavBarButton>
-                    ) : (
-                      <NavBarButton
-                        tab-index="0"
-                        type="link"
-                        onClick={() => {
-                          history.push(path);
-                        }}
-                      >
-                        {link}
-                      </NavBarButton>
-                    )}
-                  </Col>
-                ))}
-                {privilegeLevel !== PrivilegeLevel.NONE && (
-                  <>
-                    {Object.entries(authLinks).map(([link, path], i) => (
-                      <Col key={i}>
-                        {path === location.pathname ? (
-                          <ActiveNavBarButton
-                            type="link"
-                            onClick={() => {
-                              history.push(path);
-                            }}
-                          >
-                            {link}
-                          </ActiveNavBarButton>
-                        ) : (
-                          <NavBarButton
-                            tab-index="0"
-                            type="link"
-                            onClick={() => {
-                              history.push(path);
-                            }}
-                          >
-                            {link}
-                          </NavBarButton>
-                        )}
-                      </Col>
-                    ))}{' '}
-                  </>
-                )}
-                {privilegeLevel === PrivilegeLevel.ADMIN && (
-                  <>
-                    {Object.entries(adminLinks).map(([link, path], i) => (
-                      <Col key={i}>
-                        {path === location.pathname ? (
-                          <ActiveNavBarButton
-                            type="link"
-                            onClick={() => {
-                              history.push(path);
-                            }}
-                          >
-                            {link}
-                          </ActiveNavBarButton>
-                        ) : (
-                          <NavBarButton
-                            tab-index="0"
-                            type="link"
-                            onClick={() => {
-                              history.push(path);
-                            }}
-                          >
-                            {link}
-                          </NavBarButton>
-                        )}
-                      </Col>
-                    ))}
-                    <Col>
-                      {asyncRequestIsComplete(personalRequests) ? (
-                        location.pathname === Routes.VIEW_REQUESTS ? (
-                          <Badge
-                            count={getNumPendingRequests(
-                              personalRequests.result,
-                            )}
-                          >
-                            <ActiveNavBarButton
-                              type="link"
-                              onClick={() => {
-                                history.push(Routes.VIEW_REQUESTS);
-                              }}
-                            >
-                              View Requests
-                            </ActiveNavBarButton>
-                          </Badge>
-                        ) : (
-                          <Badge
-                            count={getNumPendingRequests(
-                              personalRequests.result,
-                            )}
-                          >
-                            <NavBarButton
-                              tab-index="0"
-                              type="link"
-                              onClick={() => {
-                                history.push(Routes.VIEW_REQUESTS);
-                              }}
-                            >
-                              View Requests
-                            </NavBarButton>
-                          </Badge>
-                        )
-                      ) : (
-                        <NavBarButton
-                          tab-index="0"
-                          type="link"
-                          onClick={() => {
-                            history.push(Routes.VIEW_REQUESTS);
-                          }}
-                        >
-                          View Requests
-                        </NavBarButton>
-                      )}
-                    </Col>
-                  </>
-                )}
-              </Row>
-            </Col>
-          </Row>
-        </LogoContainer>
-
-        <UserContainer>
-          <Row gutter={[8, 0]}>
-            {privilegeLevel !== PrivilegeLevel.NONE ? (
-              <Col>
-                <UserDropdown
-                  overlay={
-                    privilegeLevel === PrivilegeLevel.ADMIN
-                      ? adminMenu
-                      : userMenu
-                  }
-                >
-                  <Button>
-                    <UserAvatar
-                      src={
-                        asyncRequestIsComplete(contacts)
-                          ? contacts.result.mainContact.profilePicture
-                          : undefined
-                      }
-                      icon={<UserOutlined />}
-                    />
-                    <Text>
-                      {asyncRequestIsComplete(contacts)
-                        ? contacts.result.mainContact.firstName +
-                          ' ' +
-                          contacts.result.mainContact.lastName
-                        : 'Loading...'}
-                    </Text>
-                    <DownOutlined />
-                  </Button>
-                </UserDropdown>
-              </Col>
-            ) : (
-              <>
-                <Col>
-                  <Button
-                    tab-index="0"
-                    onClick={() => {
-                      setDisplayLoginModal(true);
-                    }}
-                  >
-                    Login
-                  </Button>
-                </Col>
-                <Col>
-                  <Button
-                    tab-index="0"
-                    type="primary"
-                    onClick={() => {
-                      history.push(Routes.SIGNUP);
-                    }}
-                  >
-                    Sign Up
-                  </Button>
-                </Col>
-              </>
-            )}
-          </Row>
-        </UserContainer>
+        <NavLinks privilegeLevel={privilegeLevel} />
+        <NavDropdown
+          privilegeLevel={privilegeLevel}
+          tokens={tokens}
+          contacts={contacts}
+          setDisplayLoginModal={setDisplayLoginModal}
+        />
       </NavBarContainer>
       <LoginModal
         showLoginModal={
@@ -516,7 +72,6 @@ const mapStateToProps = (state: C4CState): NavBarProps => {
   return {
     tokens: state.authenticationState.tokens,
     contacts: state.contactsState.contacts,
-    personalRequests: state.personalRequestsState.personalRequests,
   };
 };
 

--- a/src/components/personalRequests/SubmitPFRequest.tsx
+++ b/src/components/personalRequests/SubmitPFRequest.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import styled from 'styled-components';
-import Paragraph from 'antd/lib/typography/Paragraph';
 import { Button } from 'antd';
+import Paragraph from 'antd/lib/typography/Paragraph';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Routes } from '../../App';
+import styled from 'styled-components';
 import ProtectedApiClient from '../../api/protectedApiClient';
-import { ORANGE, DEEP_GREEN } from '../../utils/colors';
+import { Routes } from '../../App';
+import { DEEP_GREEN, ORANGE } from '../../utils/colors';
 
 export interface SubmitPFRequestProps {
   onNewRequest: () => void;
@@ -52,8 +52,8 @@ export const SubmitPFRequest: React.FC<SubmitPFRequestProps> = ({
 }) => {
   const history = useHistory();
 
-  const onApplyToBePF = () => {
-    ProtectedApiClient.makePFRequest();
+  const onApplyToBePF = async () => {
+    await ProtectedApiClient.makePFRequest();
     onNewRequest();
   };
 
@@ -68,7 +68,7 @@ export const SubmitPFRequest: React.FC<SubmitPFRequestProps> = ({
           Add your family information by editing your account details. This will
           act as your application.
         </StyledText>
-        <StyledButton onClick={() => history.push(Routes.EDIT_FAMILY_INFO)}>
+        <StyledButton onClick={() => history.push(Routes.SET_CONTACTS)}>
           Edit Account Details
         </StyledButton>
         <StyledText>

--- a/src/containers/personalRequests/index.tsx
+++ b/src/containers/personalRequests/index.tsx
@@ -1,25 +1,25 @@
+import { Button, Typography } from 'antd';
 import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { Button, Typography } from 'antd';
+import { connect, useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { Routes } from '../../App';
+import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { PrivilegeLevel } from '../../auth/ducks/types';
 import { ChungusContentContainer } from '../../components';
-import { getRequestStatuses } from './ducks/thunks';
+import { InfoModal } from '../../components/InfoModal';
+import { PreviousRequests } from '../../components/personalRequests/PreviousRequests';
+import { SubmitPFRequest } from '../../components/personalRequests/SubmitPFRequest';
+import { C4CState } from '../../store';
 import {
   asyncRequestIsComplete,
   asyncRequestIsFailed,
   asyncRequestIsLoading,
 } from '../../utils/asyncRequest';
-import { connect, useDispatch, useSelector } from 'react-redux';
-import { PersonalRequestsReducerState } from './ducks/types';
-import { C4CState } from '../../store';
-import { InfoModal } from '../../components/InfoModal';
-import { Routes } from '../../App';
-import { Link } from 'react-router-dom';
-import { getPrivilegeLevel } from '../../auth/ducks/selectors';
-import { PrivilegeLevel } from '../../auth/ducks/types';
-import { PreviousRequests } from '../../components/personalRequests/PreviousRequests';
-import { SubmitPFRequest } from '../../components/personalRequests/SubmitPFRequest';
 import { hasPendingRequest } from './ducks/selectors';
+import { getRequestStatuses } from './ducks/thunks';
+import { PersonalRequestsReducerState } from './ducks/types';
 
 const { Title } = Typography;
 
@@ -160,7 +160,7 @@ const PersonalRequests: React.FC<PersonalRequestsProps> = ({
               </StyledSubTitle>
               {asyncRequestIsComplete(personalRequests) && (
                 <>
-                  {personalRequests.result.length && (
+                  {personalRequests.result.length > 0 && (
                     <PreviousRequests requests={personalRequests.result} />
                   )}
                   {!hasPendingRequest(personalRequests.result) && (

--- a/src/containers/singleEvent/index.tsx
+++ b/src/containers/singleEvent/index.tsx
@@ -7,14 +7,14 @@ import styled from 'styled-components';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import {
   PrivilegeLevel,
-  UserAuthenticationReducerState,
+  UserAuthenticationReducerState
 } from '../../auth/ducks/types';
 import EventDetails from '../../components/event-details/EventDetails';
 import { LinkButton } from '../../components/LinkButton';
 import { C4CState } from '../../store';
 import {
   asyncRequestIsComplete,
-  asyncRequestIsFailed,
+  asyncRequestIsFailed
 } from '../../utils/asyncRequest';
 import { getMyEvents } from '../myEvents/ducks/thunks';
 import { MyEventsReducerState } from '../myEvents/ducks/types';
@@ -120,13 +120,6 @@ const SingleEvent: React.FC<SingleEventProps> = ({
     return getPrivilegeLevel(state.authenticationState.tokens);
   });
 
-  const hasRegistered: boolean = useSelector((state: C4CState) => {
-    return (
-      asyncRequestIsComplete(state.myEventsState.myEvents) &&
-      state.myEventsState.myEvents.result.some((e) => e.id === id)
-    );
-  });
-
   const conditionalRenderEventDetails = () => {
     if (
       asyncRequestIsComplete(events) &&
@@ -136,7 +129,7 @@ const SingleEvent: React.FC<SingleEventProps> = ({
       const event =
         myEvents.result.find((e) => e.id === id) ||
         events.result.find((e) => e.id === id);
-
+      const hasRegistered = (event && event.ticketCount && event.ticketCount > 0) !== undefined;
       if (event) {
         return (
           <>

--- a/src/containers/singleEvent/index.tsx
+++ b/src/containers/singleEvent/index.tsx
@@ -7,14 +7,14 @@ import styled from 'styled-components';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import {
   PrivilegeLevel,
-  UserAuthenticationReducerState
+  UserAuthenticationReducerState,
 } from '../../auth/ducks/types';
 import EventDetails from '../../components/event-details/EventDetails';
 import { LinkButton } from '../../components/LinkButton';
 import { C4CState } from '../../store';
 import {
   asyncRequestIsComplete,
-  asyncRequestIsFailed
+  asyncRequestIsFailed,
 } from '../../utils/asyncRequest';
 import { getMyEvents } from '../myEvents/ducks/thunks';
 import { MyEventsReducerState } from '../myEvents/ducks/types';
@@ -129,7 +129,8 @@ const SingleEvent: React.FC<SingleEventProps> = ({
       const event =
         myEvents.result.find((e) => e.id === id) ||
         events.result.find((e) => e.id === id);
-      const hasRegistered = (event && event.ticketCount && event.ticketCount > 0) !== undefined;
+      const hasRegistered =
+        (event && event.ticketCount && event.ticketCount > 0) !== undefined;
       if (event) {
         return (
           <>

--- a/src/containers/viewSingleRequest/index.tsx
+++ b/src/containers/viewSingleRequest/index.tsx
@@ -1,5 +1,15 @@
-import { useParams } from 'react-router-dom';
+import { Alert, Button, Spin } from 'antd';
 import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { useHistory } from 'react-router';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+import protectedApiClient from '../../api/protectedApiClient';
+import { PrivilegeLevel } from '../../auth/ducks/types';
+import { ChungusContentContainer } from '../../components';
+import ContactInfoSummary from '../../components/ContactInfoSummary';
+import DecisionConfirmation from '../../components/DecisionConfirmation';
+import { LinkButton } from '../../components/LinkButton';
 import {
   AsyncRequest,
   AsyncRequestCompleted,
@@ -12,16 +22,6 @@ import {
   AsyncRequestNotStarted,
 } from '../../utils/asyncRequest';
 import { ContactInfo } from '../setContacts/ducks/types';
-import { Helmet } from 'react-helmet';
-import { ChungusContentContainer } from '../../components';
-import ContactInfoSummary from '../../components/ContactInfoSummary';
-import { Alert, Button, Spin } from 'antd';
-import styled from 'styled-components';
-import { LinkButton } from '../../components/LinkButton';
-import protectedApiClient from '../../api/protectedApiClient';
-import DecisionConfirmation from '../../components/DecisionConfirmation';
-import { PrivilegeLevel } from '../../auth/ducks/types';
-import { useHistory } from 'react-router';
 
 enum Status {
   PENDING,
@@ -33,6 +33,7 @@ const DecisionButtons = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-bottom: 3em;
 `;
 
 const StyledButton = styled(Button)`
@@ -95,7 +96,7 @@ const ViewSingleRequest = () => {
             !c.privilegeLevel ||
             c.privilegeLevel.toLowerCase() !== PrivilegeLevel.STANDARD
           ) {
-            history.push('/404');
+            history.replace('/not-found');
           }
         })
         .catch((error) => {


### PR DESCRIPTION
Note: PUT request functionality requires fixing bug on backend. 
PR: https://github.com/Code-4-Community/lucys-love-bus-backend/pull/127

## Changes

- Added PUT request for checkout to protectedApiClient
- Determined if user is registering for new tickets or updating a current registration, then passed the info to modal
- Modal ticket quantity is fed initial value of current ticket count
- Modal calls correct PUT or POST method depending on props
- Event details now displays event ticket count
- After updating/creating tickets, myEvents is automatically refreshed to display new ticket count instantly

## Screenshots

Provide screenshots of any new components, styling changes, or pages. 

![image](https://user-images.githubusercontent.com/23691775/115750965-b4307b80-a366-11eb-86b4-484c865f7f1d.png)
![image](https://user-images.githubusercontent.com/23691775/115750997-bbf02000-a366-11eb-9c88-8641d4306797.png)
![image](https://user-images.githubusercontent.com/23691775/115751243-ff4a8e80-a366-11eb-8111-4ad7f6f40305.png)

![image](https://user-images.githubusercontent.com/23691775/115751364-22753e00-a367-11eb-90a1-d5eddf1567e8.png)
![image](https://user-images.githubusercontent.com/23691775/115751403-299c4c00-a367-11eb-9126-4e13575ea6d7.png)
![image](https://user-images.githubusercontent.com/23691775/115751425-2d2fd300-a367-11eb-99b4-4993e75bc5d7.png)
