### PR TITLE
Change Password Form Bug fix

### DIFF
--- a/src/containers/changePassword/index.tsx
+++ b/src/containers/changePassword/index.tsx
@@ -59,7 +59,7 @@ const ChangePassword: React.FC = () => {
               },
               ({ getFieldValue }) => ({
                 validator(_, value) {
-                  if (!value || getFieldValue('password') === value) {
+                  if (!value || getFieldValue('newPassword') === value) {
                     return Promise.resolve();
                   }
                   return Promise.reject(


### PR DESCRIPTION
## Changes

bug fix - Change password form was comparing the confirmation password to field value "password" but the value is called "newPassword"

## Verification Steps

Manually tested it 
