### PR TITLE
Added User Directory to Navigation and Ticket Counts to RSVP View

### DIFF
--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -62,9 +62,10 @@ const NavLinks: React.FC<{ privilegeLevel: PrivilegeLevel }> = ({
     'My Requests': Routes.PERSONAL_REQUESTS,
   };
   const adminLinks = {
-    'Create Event': Routes.CREATE_EVENT,
-    'Make Announcement': Routes.CREATE_ANNOUNCEMENTS,
+    // 'Create Event': Routes.CREATE_EVENT,
+    // 'Make Announcement': Routes.CREATE_ANNOUNCEMENTS,
     'View Requests': Routes.VIEW_REQUESTS,
+    'View All Users': Routes.USER_DIRECTORY,
   };
   return (
     <LogoContainer>

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -62,8 +62,6 @@ const NavLinks: React.FC<{ privilegeLevel: PrivilegeLevel }> = ({
     'My Requests': Routes.PERSONAL_REQUESTS,
   };
   const adminLinks = {
-    // 'Create Event': Routes.CREATE_EVENT,
-    // 'Make Announcement': Routes.CREATE_ANNOUNCEMENTS,
     'View Requests': Routes.VIEW_REQUESTS,
     'View All Users': Routes.USER_DIRECTORY,
   };

--- a/src/containers/announcements/index.tsx
+++ b/src/containers/announcements/index.tsx
@@ -67,7 +67,7 @@ const Announcements: React.FC<AnnouncementsDataProps> = ({ announcements }) => {
             <Content>
               <StyledTitle>Announcements</StyledTitle>
               {privilegeLevel === PrivilegeLevel.ADMIN && (
-                <LinkButton type="primary" to={Routes.CREATE_ANNOUNCEMENTS}>
+                <LinkButton type="primary" to={'/create-announcements'}>
                   Make Announcement
                 </LinkButton>
               )}

--- a/src/containers/announcements/index.tsx
+++ b/src/containers/announcements/index.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { Routes } from '../../App';
 import { getPrivilegeLevel } from '../../auth/ducks/selectors';
 import { PrivilegeLevel } from '../../auth/ducks/types';
 import { ChungusContentContainer } from '../../components';

--- a/src/containers/announcements/index.tsx
+++ b/src/containers/announcements/index.tsx
@@ -1,10 +1,14 @@
 import { Alert, Spin, Typography } from 'antd';
 import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { Routes } from '../../App';
+import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { PrivilegeLevel } from '../../auth/ducks/types';
 import { ChungusContentContainer } from '../../components';
 import AnnouncementsList from '../../components/announcementsList';
+import { LinkButton } from '../../components/LinkButton';
 import { C4CState } from '../../store';
 import {
   asyncRequestIsComplete,
@@ -36,7 +40,9 @@ const Announcements: React.FC<AnnouncementsDataProps> = ({ announcements }) => {
   useEffect(() => {
     dispatch(getAnnouncements());
   }, [dispatch]);
-
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) => {
+    return getPrivilegeLevel(state.authenticationState.tokens);
+  });
   return (
     <>
       <Helmet>
@@ -60,6 +66,11 @@ const Announcements: React.FC<AnnouncementsDataProps> = ({ announcements }) => {
           <>
             <Content>
               <StyledTitle>Announcements</StyledTitle>
+              {privilegeLevel === PrivilegeLevel.ADMIN && (
+                <LinkButton type="primary" to={Routes.CREATE_ANNOUNCEMENTS}>
+                  Make Announcement
+                </LinkButton>
+              )}
             </Content>
             <AnnouncementsList announcements={announcements.result} />
           </>

--- a/src/containers/eventRSVP/ducks/types.tsx
+++ b/src/containers/eventRSVP/ducks/types.tsx
@@ -14,6 +14,7 @@ export interface Registration {
   phoneNumber: string;
   profilePicture: string | null;
   photoRelease: boolean;
+  ticketCount?: number;
 }
 
 export type EventRegistrationsReducerState = {

--- a/src/containers/eventRSVP/index.tsx
+++ b/src/containers/eventRSVP/index.tsx
@@ -81,6 +81,11 @@ const EventRSVP: React.FC<EventRSVPProps> = ({ events, registrations }) => {
       render: TablePhotoConsent,
     },
     {
+      title: 'Tickets Registered',
+      dataIndex: 'ticketCount',
+      key: 'ticketCount',
+    },
+    {
       title: 'Action',
       key: 'action',
       render: TableActions,

--- a/src/containers/home/index.tsx
+++ b/src/containers/home/index.tsx
@@ -132,7 +132,7 @@ const Home: React.FC<HomeContainerProps> = ({ events, announcements }) => {
                 </LinkButton>
               </AdminCol>
               <AdminCol>
-                <LinkButton type="primary" to={Routes.CREATE_ANNOUNCEMENTS}>
+                <LinkButton type="primary" to={'/create-announcements'}>
                   Make Announcement
                 </LinkButton>
               </AdminCol>

--- a/src/containers/upcoming-events/index.tsx
+++ b/src/containers/upcoming-events/index.tsx
@@ -1,11 +1,15 @@
-import { Radio, Typography } from 'antd';
+import { Radio, Typography, Button } from 'antd';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { Routes } from '../../App';
+import { getPrivilegeLevel } from '../../auth/ducks/selectors';
+import { PrivilegeLevel } from '../../auth/ducks/types';
 import { ChungusContentContainer } from '../../components';
 import Calendar from '../../components/Calendar';
 import EventsList from '../../components/events-list/EventsList';
+import { LinkButton } from '../../components/LinkButton';
 import { C4CState } from '../../store';
 import { asyncRequestIsComplete } from '../../utils/asyncRequest';
 import { getUpcomingEvents } from './ducks/thunks';
@@ -44,6 +48,9 @@ const UpcomingEvents: React.FC<UpcomingEventsProps> = ({ events }) => {
   }, [dispatch]);
 
   const [view, setView] = useState<EventView>(EventView.List);
+  const privilegeLevel: PrivilegeLevel = useSelector((state: C4CState) => {
+    return getPrivilegeLevel(state.authenticationState.tokens);
+  });
 
   return (
     <>
@@ -68,6 +75,11 @@ const UpcomingEvents: React.FC<UpcomingEventsProps> = ({ events }) => {
               Calendar
             </Radio.Button>
           </StyledRadio>
+          {privilegeLevel === PrivilegeLevel.ADMIN && (
+            <LinkButton type="primary" to={Routes.CREATE_EVENT}>
+              Create Event
+            </LinkButton>
+          )}
         </Content>
 
         {asyncRequestIsComplete(events) &&

--- a/src/containers/upcoming-events/index.tsx
+++ b/src/containers/upcoming-events/index.tsx
@@ -1,4 +1,4 @@
-import { Radio, Typography, Button } from 'antd';
+import { Radio, Typography } from 'antd';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect, useDispatch, useSelector } from 'react-redux';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
-import "react-app-polyfill/ie11";
-import "react-app-polyfill/stable";
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';


### PR DESCRIPTION
## Issue

Addressed the two issues before our meeting later this week.

## Changes
- Removed Make Announcement and Create Event navbar links, added buttons to upcoming events and announcements pages instead
- Added View All Users to navbar
- Added ticket count to Registration interface
- Added ticket count column to RSVP data table

## Screenshots
![image](https://user-images.githubusercontent.com/23691775/121093379-f436ab00-c7ba-11eb-8021-d24fce1c5c1e.png)
![image](https://user-images.githubusercontent.com/23691775/121093363-ef71f700-c7ba-11eb-9ad9-d5bd67e4aeb1.png)
![image](https://user-images.githubusercontent.com/23691775/121093393-f862c880-c7ba-11eb-855f-670f1e8b28e8.png)
![image](https://user-images.githubusercontent.com/23691775/121093424-03b5f400-c7bb-11eb-8992-abbc8aba6579.png)
![image](https://user-images.githubusercontent.com/23691775/121093435-07497b00-c7bb-11eb-89aa-3311902b14d7.png)

